### PR TITLE
Add class-scoped Teach quick action

### DIFF
--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -3536,6 +3536,13 @@ class _ClassroomTile extends StatelessWidget {
         route: AppRoutes.osClassWorkspace(classId),
       ),
       _ClassQuickTool(
+        label: 'Teach',
+        icon: Icons.cast_for_education_rounded,
+        color: OSColors.teachAccent,
+        route: AppRoutes.osTeach,
+        surface: OSSurface.teach,
+      ),
+      _ClassQuickTool(
         label: 'Seating',
         icon: Icons.event_seat_rounded,
         color: OSColors.amber,
@@ -3645,10 +3652,18 @@ class _ClassroomTile extends StatelessWidget {
                       child: _ClassQuickToolButton(
                         tool: tool,
                         className: classItem.className,
-                        onTap: () => context.go(tool.route),
+                        onTap: () {
+                          if (tool.surface == OSSurface.teach) {
+                            context.read<GradeFlowOSController>().setSurface(
+                                  OSSurface.teach,
+                                  classId: classId,
+                                );
+                          }
+                          context.go(tool.route);
+                        },
                       ),
                     ),
-                    if (tool != tools.last) const SizedBox(width: 7),
+                    if (tool != tools.last) const SizedBox(width: 6),
                   ],
                 ],
               ),
@@ -3666,12 +3681,14 @@ class _ClassQuickTool {
     required this.icon,
     required this.color,
     required this.route,
+    this.surface,
   });
 
   final String label;
   final IconData icon;
   final Color color;
   final String route;
+  final OSSurface? surface;
 }
 
 class _ClassQuickToolButton extends StatelessWidget {
@@ -3697,7 +3714,7 @@ class _ClassQuickToolButton extends StatelessWidget {
         child: OSTouchFeedback(
           onTap: onTap,
           borderRadius: OSRadius.pillBr,
-          minSize: const Size(32, 32),
+          minSize: const Size(30, 32),
           child: Container(
             alignment: Alignment.center,
             padding: const EdgeInsets.symmetric(vertical: 7),
@@ -3712,7 +3729,7 @@ class _ClassQuickToolButton extends StatelessWidget {
             ),
             child: Icon(
               tool.icon,
-              size: 14,
+              size: 13,
               color: tool.color,
             ),
           ),


### PR DESCRIPTION
## Summary

Adds a compact class-scoped Teach quick action to each OS Home class tile.

## What changed

- Adds `Teach` as a sixth quick action beside Workspace, Seating, Gradebook, Schedule, and Whiteboard.
- Keeps the existing `/os/teach` route unchanged.
- Before navigating to Teach, the class tile writes the selected class into `GradeFlowOSController`:

```dart
context.read<GradeFlowOSController>().setSurface(
  OSSurface.teach,
  classId: classId,
);
```

- Then navigates to:

```dart
context.go(AppRoutes.osTeach);
```

This uses the existing controller behavior where `setSurface(OSSurface.teach)` preserves the current `activeClassId` when no new class id is passed by the route frame.

## Safety notes

- No route changes.
- No query params.
- No `/os/teach/:classId` route added.
- No service, Firebase, data, dock, launcher, or TeachSurface changes.
- Existing class quick actions still route to the same destinations.

## Verification

Local checks reported before push:

```text
flutter analyze: No errors
focused tests: All tests passed (+11)
flutter build web: successful
```

Visual checks reported:

- `/os/home` desktop around `1440x900`: passed, six quick actions fit without overflow.
- `/os/home` mobile around `390x844`: passed.
- Teach launched from a class tile and showed the selected class context.
- No RenderFlex overflow logs found.

Non-blocking warnings:

- Existing wasm dry-run warnings from third-party `image-4.3.0` in Pub cache.
- Headless Chromium CPU-only rendering warning due to WebGL not detected.