### PR TITLE
Add classroom command map presentation mode and tighten class workspace density

### DIFF
--- a/lib/components/seating/seating_designer_view.dart
+++ b/lib/components/seating/seating_designer_view.dart
@@ -14,6 +14,7 @@ class SeatingDesignerView extends StatefulWidget {
   final List<Student> students;
   final bool autoLoad;
   final bool presentationMode;
+  final bool showToolbar;
   final bool showStudentPanel;
   final bool showFullScreenButton;
   final bool showUseHint;
@@ -29,6 +30,7 @@ class SeatingDesignerView extends StatefulWidget {
     required this.students,
     this.autoLoad = true,
     this.presentationMode = false,
+    this.showToolbar = true,
     this.showStudentPanel = true,
     this.showFullScreenButton = true,
     this.showUseHint = true,
@@ -115,62 +117,64 @@ class _SeatingDesignerViewState extends State<SeatingDesignerView> {
             return Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                _SeatingDesignerToolBand(
-                  child: SeatingToolbar(
-                    layouts: layouts,
-                    activeLayoutId: active.layoutId,
-                    designMode: _designMode,
-                    onToggleDesignMode: () =>
-                        setState(() => _designMode = !_designMode),
-                    onSelectLayout: (id) =>
-                        service.selectLayout(widget.classId, id),
-                    onAddLayout: () => _promptNewLayout(context, service),
-                    onDuplicateLayout: () => _duplicateLayout(service, active),
-                    onApplyTemplate: (template) => service.applyTemplate(
-                        widget.classId, template, widget.students.length),
-                    onAddRectTable: () => service.addTable(
-                        widget.classId, SeatingTableType.rectangular,
-                        seatCount: 4),
-                    onAddSquareTable: () => service.addTable(
-                        widget.classId, SeatingTableType.square,
-                        seatCount: 4),
-                    onAddDesk: () => service.addTable(
-                        widget.classId, SeatingTableType.singleDesk,
-                        seatCount: 1),
-                    onAddTeacherDesk: () => service.addTable(
-                        widget.classId, SeatingTableType.teacherDesk,
-                        seatCount: 0),
-                    onRenameLayout: () =>
-                        _promptRenameLayout(context, service, active),
-                    onClearRoom: () =>
-                        _confirmClearRoom(context, service, active),
-                    onDeleteLayout: () =>
-                        _confirmDeleteLayout(context, service, layouts, active),
-                    onRoomSettings: () =>
-                        _promptRoomSettings(context, service, active),
-                    onAutoAssign: () =>
-                        _autoAssignStudents(context, service, active),
-                    onShuffleSeating: () =>
-                        _shuffleSeating(context, service, active),
-                    onClearAssignments: () =>
-                        _confirmClearAssignments(context, service, active),
-                    onPickStudent: () => _showStudentPicker(
-                        context, service, active, studentsById),
-                    onOpenRoomSetups: widget.onOpenRoomSetups,
-                    onPreviewPdf: widget.onPreviewPdf,
-                    onPrint: widget.onPrint,
-                    onDownload: widget.onDownload,
-                    webMode: widget.webMode,
-                    showFullScreenButton: widget.showFullScreenButton,
-                    onFullScreen: () =>
-                        Navigator.of(context).push(MaterialPageRoute(
-                      builder: (_) => _FullScreenSeatingRoute(
-                        classId: widget.classId,
-                        students: widget.students,
-                      ),
-                    )),
+                if (widget.showToolbar)
+                  _SeatingDesignerToolBand(
+                    child: SeatingToolbar(
+                      layouts: layouts,
+                      activeLayoutId: active.layoutId,
+                      designMode: _designMode,
+                      onToggleDesignMode: () =>
+                          setState(() => _designMode = !_designMode),
+                      onSelectLayout: (id) =>
+                          service.selectLayout(widget.classId, id),
+                      onAddLayout: () => _promptNewLayout(context, service),
+                      onDuplicateLayout: () =>
+                          _duplicateLayout(service, active),
+                      onApplyTemplate: (template) => service.applyTemplate(
+                          widget.classId, template, widget.students.length),
+                      onAddRectTable: () => service.addTable(
+                          widget.classId, SeatingTableType.rectangular,
+                          seatCount: 4),
+                      onAddSquareTable: () => service.addTable(
+                          widget.classId, SeatingTableType.square,
+                          seatCount: 4),
+                      onAddDesk: () => service.addTable(
+                          widget.classId, SeatingTableType.singleDesk,
+                          seatCount: 1),
+                      onAddTeacherDesk: () => service.addTable(
+                          widget.classId, SeatingTableType.teacherDesk,
+                          seatCount: 0),
+                      onRenameLayout: () =>
+                          _promptRenameLayout(context, service, active),
+                      onClearRoom: () =>
+                          _confirmClearRoom(context, service, active),
+                      onDeleteLayout: () => _confirmDeleteLayout(
+                          context, service, layouts, active),
+                      onRoomSettings: () =>
+                          _promptRoomSettings(context, service, active),
+                      onAutoAssign: () =>
+                          _autoAssignStudents(context, service, active),
+                      onShuffleSeating: () =>
+                          _shuffleSeating(context, service, active),
+                      onClearAssignments: () =>
+                          _confirmClearAssignments(context, service, active),
+                      onPickStudent: () => _showStudentPicker(
+                          context, service, active, studentsById),
+                      onOpenRoomSetups: widget.onOpenRoomSetups,
+                      onPreviewPdf: widget.onPreviewPdf,
+                      onPrint: widget.onPrint,
+                      onDownload: widget.onDownload,
+                      webMode: widget.webMode,
+                      showFullScreenButton: widget.showFullScreenButton,
+                      onFullScreen: () =>
+                          Navigator.of(context).push(MaterialPageRoute(
+                        builder: (_) => _FullScreenSeatingRoute(
+                          classId: widget.classId,
+                          students: widget.students,
+                        ),
+                      )),
+                    ),
                   ),
-                ),
                 if (widget.showUseHint && _designMode) ...[
                   const SizedBox(height: 6),
                   _EditRoomHint(
@@ -182,7 +186,9 @@ class _SeatingDesignerViewState extends State<SeatingDesignerView> {
                   const SizedBox(height: 6),
                   const _SeatingUseHint(),
                 ],
-                SizedBox(height: widget.showUseHint ? 8 : 6),
+                SizedBox(
+                  height: widget.showToolbar || widget.showUseHint ? 8 : 0,
+                ),
                 Expanded(
                   child: !showStudentPanel
                       ? _buildCanvas(context, service, active, studentsById)

--- a/lib/os/surfaces/class_surface.dart
+++ b/lib/os/surfaces/class_surface.dart
@@ -164,6 +164,7 @@ class _ClassSurfaceState extends State<ClassSurface>
                     classId: widget.classId,
                     className: className,
                     subject: subject,
+                    compact: isCompact,
                     onBack: _goBackHome,
                     onOpenFullView: () {
                       context.go('${AppRoutes.classDetail}/${widget.classId}');
@@ -354,6 +355,7 @@ class _ClassWorkspaceHero extends StatelessWidget {
     required this.classId,
     required this.className,
     required this.subject,
+    required this.compact,
     required this.onBack,
     required this.onOpenFullView,
   });
@@ -361,6 +363,7 @@ class _ClassWorkspaceHero extends StatelessWidget {
   final String classId;
   final String className;
   final String subject;
+  final bool compact;
   final VoidCallback onBack;
   final VoidCallback onOpenFullView;
 
@@ -375,7 +378,9 @@ class _ClassWorkspaceHero extends StatelessWidget {
 
     return GradeFlowPanel(
       variant: GradeFlowPanelVariant.stage,
-      padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+      padding: compact
+          ? const EdgeInsets.fromLTRB(14, 12, 14, 12)
+          : const EdgeInsets.fromLTRB(16, 14, 16, 14),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -394,13 +399,13 @@ class _ClassWorkspaceHero extends StatelessWidget {
                 ),
               ),
               GradeFlowActionChip(
-                label: 'View full class',
+                label: compact ? 'Full class' : 'View full class',
                 icon: Icons.open_in_new_rounded,
                 onPressed: onOpenFullView,
               ),
             ],
           ),
-          const SizedBox(height: 12),
+          SizedBox(height: compact ? 8 : 12),
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -410,11 +415,11 @@ class _ClassWorkspaceHero extends StatelessWidget {
                 iconSize: 18,
                 color: OSColors.textSubtle(dark),
                 style: IconButton.styleFrom(
-                  minimumSize: const Size(36, 36),
+                  minimumSize: Size(compact ? 32 : 36, compact ? 32 : 36),
                   tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                 ),
               ),
-              const SizedBox(width: 8),
+              SizedBox(width: compact ? 6 : 8),
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -427,31 +432,32 @@ class _ClassWorkspaceHero extends StatelessWidget {
                         Text(
                           className,
                           style: TextStyle(
-                            fontSize: 42,
+                            fontSize: compact ? 30 : 42,
                             fontWeight: FontWeight.w800,
-                            letterSpacing: -1.2,
+                            letterSpacing: 0,
                             color: OSColors.textPrimary(dark),
                           ),
                         ),
                         Text(
                           subject,
                           style: TextStyle(
-                            fontSize: 42,
+                            fontSize: compact ? 30 : 42,
                             fontWeight: FontWeight.w700,
-                            letterSpacing: -1.0,
+                            letterSpacing: 0,
                             color: OSColors.blueSoft,
                           ),
                         ),
                       ],
                     ),
-                    const SizedBox(height: 8),
+                    SizedBox(height: compact ? 6 : 8),
                     Wrap(
-                      spacing: 14,
-                      runSpacing: 6,
-                      children: const [
-                        _MetaItem(label: 'Term 2'),
-                        _MetaItem(label: 'Live now', accent: OSColors.green),
-                        _MetaItem(label: 'Class OS workspace'),
+                      spacing: compact ? 10 : 14,
+                      runSpacing: compact ? 4 : 6,
+                      children: [
+                        const _MetaItem(label: 'Term 2'),
+                        const _MetaItem(
+                            label: 'Live now', accent: OSColors.green),
+                        if (!compact) _MetaItem(label: 'Class OS workspace'),
                       ],
                     ),
                   ],
@@ -459,36 +465,40 @@ class _ClassWorkspaceHero extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 14),
-          Wrap(
-            spacing: 10,
-            runSpacing: 10,
-            children: [
-              GradeFlowMetricPill(
-                icon: Icons.people_alt_outlined,
-                label: 'Students',
-                value: '$studentCount',
-                accent: OSColors.blue,
-              ),
-              const GradeFlowMetricPill(
-                icon: Icons.check_circle_outline,
-                label: 'Attendance',
-                value: '92%',
-                accent: OSColors.green,
-              ),
-              const GradeFlowMetricPill(
-                icon: Icons.insights_outlined,
-                label: 'Class average',
-                value: '84.3',
-                accent: OSColors.cyan,
-              ),
-              const GradeFlowMetricPill(
-                icon: Icons.assignment_turned_in_outlined,
-                label: 'Activities',
-                value: '12',
-                accent: OSColors.indigo,
-              ),
-            ],
+          SizedBox(height: compact ? 10 : 14),
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                GradeFlowMetricPill(
+                  icon: Icons.people_alt_outlined,
+                  label: 'Students',
+                  value: '$studentCount',
+                  accent: OSColors.blue,
+                ),
+                const SizedBox(width: 10),
+                const GradeFlowMetricPill(
+                  icon: Icons.check_circle_outline,
+                  label: 'Attendance',
+                  value: '92%',
+                  accent: OSColors.green,
+                ),
+                const SizedBox(width: 10),
+                const GradeFlowMetricPill(
+                  icon: Icons.insights_outlined,
+                  label: 'Class average',
+                  value: '84.3',
+                  accent: OSColors.cyan,
+                ),
+                const SizedBox(width: 10),
+                const GradeFlowMetricPill(
+                  icon: Icons.assignment_turned_in_outlined,
+                  label: 'Activities',
+                  value: '12',
+                  accent: OSColors.indigo,
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/lib/screens/class_seating_screen.dart
+++ b/lib/screens/class_seating_screen.dart
@@ -12,6 +12,7 @@ import 'package:gradeflow/components/workspace_shell.dart';
 import 'package:gradeflow/models/class.dart';
 import 'package:gradeflow/models/room_setup.dart';
 import 'package:gradeflow/models/seating_layout.dart';
+import 'package:gradeflow/models/student.dart';
 import 'package:gradeflow/os/os_palette.dart';
 import 'package:gradeflow/platform/browser_file_actions.dart';
 import 'package:gradeflow/services/auth_service.dart';
@@ -38,6 +39,7 @@ class _ClassSeatingScreenState extends State<ClassSeatingScreen> {
   final ExportService _exportService = ExportService();
   bool _isBootstrapping = true;
   bool _isBuildingHandout = false;
+  bool _presentationMode = false;
 
   void _goToClassWorkspace() {
     context.go('${AppRoutes.osClass}/${widget.classId}');
@@ -129,11 +131,17 @@ class _ClassSeatingScreenState extends State<ClassSeatingScreen> {
         0;
     final seatCount = activeLayout?.seats.length ?? 0;
     final tableCount = activeLayout?.tables.length ?? 0;
+    final emptySeatCount = (seatCount - placedSeatCount).clamp(0, seatCount);
+    final signalSummary = _StudentSignalSummary.from(
+      students: students,
+      activeLayout: activeLayout,
+    );
 
     return _SeatingNativeSurface(
       eyebrow: 'Class workspace',
       title: classItem.className,
-      toolLabel: 'Classroom Map',
+      toolLabel:
+          _presentationMode ? 'Presentation Mode' : 'Classroom Command Map',
       subtitle:
           '${classItem.subject} - ${classItem.schoolYear} - ${classItem.term}',
       leading: IconButton(
@@ -142,10 +150,15 @@ class _ClassSeatingScreenState extends State<ClassSeatingScreen> {
         tooltip: 'Back to class workspace',
       ),
       trailing: [
-        PilotFeedbackIconButton(
-          initialArea: 'Seating',
-          initialRoute: AppRoutes.osClassSeating(widget.classId),
+        _PresentationModeToggle(
+          enabled: _presentationMode,
+          onChanged: (enabled) => setState(() => _presentationMode = enabled),
         ),
+        if (!_presentationMode)
+          PilotFeedbackIconButton(
+            initialArea: 'Seating',
+            initialRoute: AppRoutes.osClassSeating(widget.classId),
+          ),
       ],
       contextStrip: _SeatingContextStrip(
         studentCount: students.length,
@@ -153,7 +166,9 @@ class _ClassSeatingScreenState extends State<ClassSeatingScreen> {
         tableCount: tableCount,
         seatCount: seatCount,
         placedSeatCount: placedSeatCount,
+        emptySeatCount: emptySeatCount,
         roomName: linkedRoom?.name,
+        presentationMode: _presentationMode,
       ),
       insightRail: _SeatingInsightRail(
         studentCount: students.length,
@@ -163,6 +178,8 @@ class _ClassSeatingScreenState extends State<ClassSeatingScreen> {
         placedSeatCount: placedSeatCount,
         roomName: linkedRoom?.name,
         activeLayout: activeLayout,
+        signalSummary: signalSummary,
+        presentationMode: _presentationMode,
       ),
       workspace: LayoutBuilder(
         builder: (context, constraints) {
@@ -171,26 +188,37 @@ class _ClassSeatingScreenState extends State<ClassSeatingScreen> {
             classId: widget.classId,
             students: students,
             autoLoad: false,
+            presentationMode: _presentationMode,
+            showToolbar: !_presentationMode,
             showStudentPanel: false,
             showUseHint: false,
-            onOpenRoomSetups:
-                activeLayout == null ? null : _showRoomSetupsDialog,
-            onPreviewPdf:
-                _isBuildingHandout ? null : () => _withHandoutPdf(_previewPdf),
-            onPrint:
-                _isBuildingHandout ? null : () => _withHandoutPdf(_printPdf),
-            onDownload: _isBuildingHandout
+            showFullScreenButton: !_presentationMode,
+            onOpenRoomSetups: _presentationMode || activeLayout == null
+                ? null
+                : _showRoomSetupsDialog,
+            onPreviewPdf: _presentationMode || _isBuildingHandout
+                ? null
+                : () => _withHandoutPdf(_previewPdf),
+            onPrint: _presentationMode || _isBuildingHandout
+                ? null
+                : () => _withHandoutPdf(_printPdf),
+            onDownload: _presentationMode || _isBuildingHandout
                 ? null
                 : () => _withHandoutPdf(_downloadOrSharePdf),
             webMode: kIsWeb,
           );
+          final mapWorkspace = _ClassroomMapWorkspace(
+            presentationMode: _presentationMode,
+            signalSummary: signalSummary,
+            child: designer,
+          );
 
-          if (!crampedHeight) return SizedBox.expand(child: designer);
+          if (!crampedHeight) return SizedBox.expand(child: mapWorkspace);
 
           return SingleChildScrollView(
             child: SizedBox(
-              height: 560,
-              child: designer,
+              height: 600,
+              child: mapWorkspace,
             ),
           );
         },
@@ -785,6 +813,302 @@ class _ClassSeatingScreenState extends State<ClassSeatingScreen> {
   }
 }
 
+class _ClassroomMapWorkspace extends StatelessWidget {
+  const _ClassroomMapWorkspace({
+    required this.presentationMode,
+    required this.signalSummary,
+    required this.child,
+  });
+
+  final bool presentationMode;
+  final _StudentSignalSummary signalSummary;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _StudentSignalRibbon(
+          summary: signalSummary,
+          presentationMode: presentationMode,
+        ),
+        SizedBox(height: presentationMode ? 12 : 10),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+
+class _PresentationModeToggle extends StatelessWidget {
+  const _PresentationModeToggle({
+    required this.enabled,
+    required this.onChanged,
+  });
+
+  final bool enabled;
+  final ValueChanged<bool> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Tooltip(
+      message: enabled
+          ? 'Return to teacher controls'
+          : 'Show a cleaner classroom map for projection',
+      child: OutlinedButton.icon(
+        onPressed: () => onChanged(!enabled),
+        icon: Icon(
+          enabled ? Icons.tune_rounded : Icons.cast_for_education_outlined,
+          size: 18,
+        ),
+        label: Text(enabled ? 'Teacher mode' : 'Present mode'),
+        style: WorkspaceButtonStyles.outlined(context, compact: true).copyWith(
+          foregroundColor: WidgetStatePropertyAll(
+            enabled ? theme.colorScheme.primary : null,
+          ),
+          side: WidgetStatePropertyAll(
+            BorderSide(
+              color: enabled
+                  ? theme.colorScheme.primary.withValues(alpha: 0.44)
+                  : WorkspaceChrome.panelBorderColor(context, emphasis: 0.9),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StudentSignalRibbon extends StatelessWidget {
+  const _StudentSignalRibbon({
+    required this.summary,
+    required this.presentationMode,
+  });
+
+  final _StudentSignalSummary summary;
+  final bool presentationMode;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final compact = constraints.maxWidth < 760;
+        final cards = [
+          _SignalCard(
+            signal: summary.behaviour,
+            accent: OSColors.green,
+            icon: Icons.self_improvement_outlined,
+          ),
+          _SignalCard(
+            signal: summary.participation,
+            accent: OSColors.cyan,
+            icon: Icons.record_voice_over_outlined,
+          ),
+          _SignalCard(
+            signal: summary.classwork,
+            accent: OSColors.blue,
+            icon: Icons.assignment_turned_in_outlined,
+          ),
+          _SignalCard(
+            signal: summary.homework,
+            accent: OSColors.amber,
+            icon: Icons.home_work_outlined,
+          ),
+        ];
+
+        if (compact) {
+          return SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                for (var i = 0; i < cards.length; i++) ...[
+                  if (i > 0) const SizedBox(width: 8),
+                  SizedBox(
+                    width: presentationMode ? 180 : 168,
+                    child: cards[i],
+                  ),
+                ],
+              ],
+            ),
+          );
+        }
+
+        return Row(
+          children: [
+            for (var i = 0; i < cards.length; i++) ...[
+              if (i > 0) const SizedBox(width: 8),
+              Expanded(child: cards[i]),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _SignalCard extends StatelessWidget {
+  const _SignalCard({
+    required this.signal,
+    required this.accent,
+    required this.icon,
+  });
+
+  final _StudentSignal signal;
+  final Color accent;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final total = signal.total == 0 ? 1 : signal.total;
+    final strength = signal.ready / total;
+
+    return WorkspaceFlatSurface(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      child: Row(
+        children: [
+          Container(
+            width: 30,
+            height: 30,
+            decoration: BoxDecoration(
+              color: accent.withValues(alpha: 0.14),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(icon, size: 17, color: accent),
+          ),
+          const SizedBox(width: 9),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  signal.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: context.textStyles.labelMedium?.copyWith(
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(999),
+                  child: LinearProgressIndicator(
+                    value: strength.clamp(0.0, 1.0),
+                    minHeight: 5,
+                    color: accent,
+                    backgroundColor:
+                        theme.colorScheme.outline.withValues(alpha: 0.16),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            '${signal.ready}/${signal.total}',
+            style: context.textStyles.labelMedium?.copyWith(
+              fontWeight: FontWeight.w900,
+              color: accent,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StudentSignalSummary {
+  const _StudentSignalSummary({
+    required this.behaviour,
+    required this.participation,
+    required this.classwork,
+    required this.homework,
+  });
+
+  final _StudentSignal behaviour;
+  final _StudentSignal participation;
+  final _StudentSignal classwork;
+  final _StudentSignal homework;
+
+  factory _StudentSignalSummary.from({
+    required List<Student> students,
+    required SeatingLayout? activeLayout,
+  }) {
+    final placedIds = (activeLayout?.seats ?? const <SeatingSeat>[])
+        .map((seat) => (seat.studentId ?? '').trim())
+        .where((id) => id.isNotEmpty)
+        .toSet();
+    final visibleStudents = placedIds.isEmpty
+        ? students
+        : students.where((student) => placedIds.contains(student.studentId));
+    final ids = visibleStudents.map((student) => student.studentId).toList();
+
+    return _StudentSignalSummary(
+      behaviour: _StudentSignal.demo(
+        label: 'Behaviour',
+        ids: ids,
+        salt: 11,
+      ),
+      participation: _StudentSignal.demo(
+        label: 'Participation',
+        ids: ids,
+        salt: 23,
+      ),
+      classwork: _StudentSignal.demo(
+        label: 'Classwork',
+        ids: ids,
+        salt: 37,
+      ),
+      homework: _StudentSignal.demo(
+        label: 'Homework',
+        ids: ids,
+        salt: 41,
+      ),
+    );
+  }
+
+  List<_StudentSignal> get all => [
+        behaviour,
+        participation,
+        classwork,
+        homework,
+      ];
+}
+
+class _StudentSignal {
+  const _StudentSignal({
+    required this.label,
+    required this.ready,
+    required this.watch,
+    required this.total,
+  });
+
+  final String label;
+  final int ready;
+  final int watch;
+  final int total;
+
+  factory _StudentSignal.demo({
+    required String label,
+    required List<String> ids,
+    required int salt,
+  }) {
+    var ready = 0;
+    for (final id in ids) {
+      if (((id.hashCode + salt).abs() % 5) < 4) ready++;
+    }
+    return _StudentSignal(
+      label: label,
+      ready: ready,
+      watch: ids.length - ready,
+      total: ids.length,
+    );
+  }
+}
+
 class _SeatingNativeSurface extends StatelessWidget {
   const _SeatingNativeSurface({
     required this.eyebrow,
@@ -823,20 +1147,24 @@ class _SeatingNativeSurface extends StatelessWidget {
       backgroundColor: Colors.transparent,
       body: AnimatedPageBackground(
         child: SafeArea(
+          bottom: false,
           child: LayoutBuilder(
             builder: (context, constraints) {
               final shellHeight = (constraints.maxHeight - shellMargin.vertical)
                   .clamp(0.0, double.infinity);
+              final visualShellHeight = shellHeight + OSSpacing.dockHeight;
 
               return Padding(
                 padding: shellMargin,
-                child: Align(
+                child: OverflowBox(
                   alignment: Alignment.topCenter,
+                  minHeight: shellHeight,
+                  maxHeight: visualShellHeight,
                   child: ConstrainedBox(
                     constraints: const BoxConstraints(maxWidth: 1480),
                     child: SizedBox(
                       width: double.infinity,
-                      height: shellHeight,
+                      height: visualShellHeight,
                       child: WorkspaceShellFrame(
                         padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
                         radius: WorkspaceRadius.shell,
@@ -897,12 +1225,16 @@ class _SeatingWorkspaceLayout extends StatelessWidget {
         );
 
         if (showRail) {
-          return Row(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
+          return Stack(
             children: [
-              Expanded(child: mapSurface),
-              const SizedBox(width: WorkspaceSpacing.sm),
-              SizedBox(
+              Positioned.fill(
+                right: 260 + WorkspaceSpacing.sm,
+                child: mapSurface,
+              ),
+              Positioned(
+                top: 0,
+                right: 0,
+                bottom: 0,
                 width: 260,
                 child: SingleChildScrollView(
                   child: insightRail!,
@@ -917,7 +1249,7 @@ class _SeatingWorkspaceLayout extends StatelessWidget {
             children: [
               SizedBox(
                 height: constraints.maxHeight,
-                child: mapSurface,
+                child: SizedBox.expand(child: mapSurface),
               ),
               if (insightRail != null) ...[
                 const SizedBox(height: WorkspaceSpacing.sm),
@@ -1022,7 +1354,7 @@ class _SeatingNativeHeader extends StatelessWidget {
             ),
             const SizedBox(height: 7),
             Text(
-              'Classroom Map',
+              'Live Classroom Map',
               maxLines: narrow ? 2 : 1,
               overflow: TextOverflow.ellipsis,
               style: context.textStyles.headlineSmall?.copyWith(
@@ -1115,6 +1447,8 @@ class _SeatingInsightRail extends StatelessWidget {
     required this.seatCount,
     required this.placedSeatCount,
     required this.activeLayout,
+    required this.signalSummary,
+    required this.presentationMode,
     this.roomName,
   });
 
@@ -1124,6 +1458,8 @@ class _SeatingInsightRail extends StatelessWidget {
   final int seatCount;
   final int placedSeatCount;
   final SeatingLayout? activeLayout;
+  final _StudentSignalSummary signalSummary;
+  final bool presentationMode;
   final String? roomName;
 
   @override
@@ -1187,6 +1523,11 @@ class _SeatingInsightRail extends StatelessWidget {
                 value:
                     (roomName ?? '').trim().isEmpty ? 'Not linked' : roomName!,
               ),
+              _RailLine(
+                icon: Icons.cast_for_education_outlined,
+                label: 'Mode',
+                value: presentationMode ? 'Presentation' : 'Teacher',
+              ),
             ],
           ),
         ),
@@ -1198,30 +1539,32 @@ class _SeatingInsightRail extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               const GradeFlowSectionHeader(
-                title: 'Seat signals',
-                subtitle: 'Existing seat status only',
+                title: 'Student signals',
+                subtitle: 'Local visual indicators',
               ),
               const SizedBox(height: WorkspaceSpacing.sm),
-              _StatusLegendRow(
-                color: Colors.green.shade600,
-                label: 'Green',
-                value: '$greenCount',
+              for (final signal in signalSummary.all)
+                _SignalRailRow(signal: signal),
+              const SizedBox(height: WorkspaceSpacing.sm),
+              const GradeFlowSectionHeader(
+                title: 'Seat status',
+                subtitle: 'Current layout marks',
               ),
+              const SizedBox(height: WorkspaceSpacing.xs),
               _StatusLegendRow(
-                color: Colors.amber.shade700,
-                label: 'Yellow',
-                value: '$yellowCount',
-              ),
+                  color: Colors.green.shade600,
+                  label: 'Green',
+                  value: '$greenCount'),
               _StatusLegendRow(
-                color: Colors.red.shade600,
-                label: 'Red',
-                value: '$redCount',
-              ),
+                  color: Colors.amber.shade700,
+                  label: 'Yellow',
+                  value: '$yellowCount'),
               _StatusLegendRow(
-                color: Colors.blue.shade600,
-                label: 'Blue',
-                value: '$blueCount',
-              ),
+                  color: Colors.red.shade600, label: 'Red', value: '$redCount'),
+              _StatusLegendRow(
+                  color: Colors.blue.shade600,
+                  label: 'Blue',
+                  value: '$blueCount'),
               const SizedBox(height: WorkspaceSpacing.xs),
               _RailLine(
                 icon: Icons.notifications_active_outlined,
@@ -1369,6 +1712,48 @@ class _StatusLegendRow extends StatelessWidget {
   }
 }
 
+class _SignalRailRow extends StatelessWidget {
+  const _SignalRailRow({required this.signal});
+
+  final _StudentSignal signal;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              signal.label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: WorkspaceTypography.metadata(context),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            '${signal.ready} steady',
+            style: context.textStyles.labelMedium?.copyWith(
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          if (signal.watch > 0) ...[
+            const SizedBox(width: 6),
+            Text(
+              '${signal.watch} watch',
+              style: context.textStyles.labelSmall?.copyWith(
+                color: WorkspaceChrome.mutedText(context),
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
 class _SeatingContextStrip extends StatelessWidget {
   const _SeatingContextStrip({
     required this.studentCount,
@@ -1376,6 +1761,8 @@ class _SeatingContextStrip extends StatelessWidget {
     required this.tableCount,
     required this.seatCount,
     required this.placedSeatCount,
+    required this.emptySeatCount,
+    required this.presentationMode,
     this.roomName,
   });
 
@@ -1384,6 +1771,8 @@ class _SeatingContextStrip extends StatelessWidget {
   final int tableCount;
   final int seatCount;
   final int placedSeatCount;
+  final int emptySeatCount;
+  final bool presentationMode;
   final String? roomName;
 
   @override
@@ -1416,6 +1805,21 @@ class _SeatingContextStrip extends StatelessWidget {
             label: 'Placed',
             value: '$placedSeatCount',
             emphasized: true,
+          ),
+          const SizedBox(width: 8),
+          WorkspaceContextPill(
+            icon: Icons.event_busy_outlined,
+            label: 'Empty',
+            value: '$emptySeatCount',
+          ),
+          const SizedBox(width: 8),
+          WorkspaceContextPill(
+            icon: Icons.cast_for_education_outlined,
+            label: 'Mode',
+            value: presentationMode ? 'Present' : 'Teacher',
+            emphasized: presentationMode,
+            accent:
+                presentationMode ? Theme.of(context).colorScheme.primary : null,
           ),
           if ((roomName ?? '').trim().isNotEmpty) ...[
             const SizedBox(width: 8),


### PR DESCRIPTION
## Summary

This PR contains two small, separated UI/UX slices for the GradeFlow OS build.

### Seating: Classroom Command Map
- Adds a route-level Teacher mode / Present mode toggle.
- Presentation mode hides teacher-only controls and gives the seating page a cleaner class-facing view.
- Adds local/read-only student signal visuals for Behaviour, Participation, Classwork, and Homework.
- Upgrades the seating header/context strip/right rail with clearer class and room status.
- Preserves the existing seating engine, drag/drop behaviour, room setup flow, PDF actions, and route behaviour.

### Class Workspace Density
- Tightens the Class Workspace hero for compact layouts.
- Reduces excessive spacing/type size on smaller screens.
- Removes negative letter spacing.
- Shortens the compact “View full class” action label.
- Makes metric pills horizontally scrollable to avoid layout pressure.

## Files changed

- lib/screens/class_seating_screen.dart
- lib/components/seating/seating_designer_view.dart
- lib/os/surfaces/class_surface.dart

## Verification

Passed:

```text
flutter analyze
flutter test test/command_surface_test.dart
flutter test test/os_palette_test.dart
flutter test test/os_shell_surfaces_test.dart
flutter build web --release
```