### PR TITLE
Add Gradebook rapid entry and active row focus

### DIFF
--- a/lib/screens/gradebook_screen.dart
+++ b/lib/screens/gradebook_screen.dart
@@ -47,6 +47,8 @@ class _GradebookScreenState extends State<GradebookScreen> {
   String? selectedCategoryId;
   String? selectedGradeItemId;
   final Map<String, TextEditingController> _controllers = {};
+  final Map<String, FocusNode> _scoreFocusNodes = {};
+  final Map<String, GlobalKey> _scoreRowKeys = {};
   final Set<String> _autoEnsuredCategories = <String>{};
 
   Future<bool> _confirmLeaveIfSaving() async {
@@ -346,6 +348,9 @@ class _GradebookScreenState extends State<GradebookScreen> {
     for (var controller in _controllers.values) {
       controller.dispose();
     }
+    for (final node in _scoreFocusNodes.values) {
+      node.dispose();
+    }
     super.dispose();
   }
 
@@ -456,6 +461,25 @@ class _GradebookScreenState extends State<GradebookScreen> {
     );
   }
 
+  FocusNode _scoreFocusNodeFor({
+    required String studentId,
+    required String gradeItemId,
+  }) {
+    final key = _scoreControllerKey(studentId, gradeItemId);
+    return _scoreFocusNodes.putIfAbsent(
+      key,
+      () => FocusNode(debugLabel: 'Gradebook score $key'),
+    );
+  }
+
+  GlobalKey _scoreRowKeyFor({
+    required String studentId,
+    required String gradeItemId,
+  }) {
+    final key = _scoreControllerKey(studentId, gradeItemId);
+    return _scoreRowKeys.putIfAbsent(key, GlobalKey.new);
+  }
+
   void _setScoreControllerText(
     String studentId,
     GradeItem item,
@@ -505,6 +529,50 @@ class _GradebookScreenState extends State<GradebookScreen> {
 
     await _updateScore(studentId, item.gradeItemId, value);
     _setScoreControllerText(studentId, item, value);
+  }
+
+  Future<bool> _moveRapidScoreFocus({
+    required List<Student> students,
+    required int currentIndex,
+    required GradeItem item,
+    required int direction,
+  }) async {
+    if (students.isEmpty || direction == 0) return false;
+
+    final nextIndex = (currentIndex + direction)
+        .clamp(
+          0,
+          students.length - 1,
+        )
+        .toInt();
+    if (nextIndex == currentIndex) return false;
+
+    final nextStudent = students[nextIndex];
+    final focusNode = _scoreFocusNodeFor(
+      studentId: nextStudent.studentId,
+      gradeItemId: item.gradeItemId,
+    );
+    final rowKey = _scoreRowKeyFor(
+      studentId: nextStudent.studentId,
+      gradeItemId: item.gradeItemId,
+    );
+
+    focusNode.requestFocus();
+    await Future<void>.delayed(Duration.zero);
+
+    final rowContext = rowKey.currentContext;
+    if (rowContext != null && mounted) {
+      await Scrollable.ensureVisible(
+        rowContext,
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOutCubic,
+        alignment: direction > 0 ? 0.72 : 0.28,
+        alignmentPolicy: direction > 0
+            ? ScrollPositionAlignmentPolicy.keepVisibleAtEnd
+            : ScrollPositionAlignmentPolicy.keepVisibleAtStart,
+      );
+    }
+    return true;
   }
 
   void _openQuickGradeSheet(int startIndex) {
@@ -926,7 +994,7 @@ class _GradebookScreenState extends State<GradebookScreen> {
                   WorkspaceSectionHeader(
                     title: 'Student scores',
                     subtitle:
-                        'Type scores directly for this assessment, or open a student sheet to enter every item for one student.',
+                        'Rapid entry: Enter moves to next student. Arrow keys move through score fields.',
                     subtitleMaxLines: 1,
                     action: FilledButton.tonalIcon(
                       onPressed: studentService.students.isEmpty
@@ -956,16 +1024,23 @@ class _GradebookScreenState extends State<GradebookScreen> {
                           gradeItemId: selectedGradeItem.gradeItemId,
                           score: current?.score,
                         );
+                        final focusNode = _scoreFocusNodeFor(
+                          studentId: student.studentId,
+                          gradeItemId: selectedGradeItem.gradeItemId,
+                        );
+                        final rowKey = _scoreRowKeyFor(
+                          studentId: student.studentId,
+                          gradeItemId: selectedGradeItem.gradeItemId,
+                        );
                         return _ScoreEntryRow(
-                          key: ValueKey(
-                            '${student.studentId}_${selectedGradeItem.gradeItemId}',
-                          ),
+                          key: rowKey,
                           studentName:
                               '${student.chineseName} • ${student.englishFullName}',
                           studentId: student.studentId,
                           seatNo: student.seatNo,
                           photoBase64: student.photoBase64,
                           controller: controller,
+                          focusNode: focusNode,
                           gradeItemId: selectedGradeItem.gradeItemId,
                           maxScore: selectedGradeItem.maxScore,
                           initialScore: current?.score,
@@ -984,6 +1059,12 @@ class _GradebookScreenState extends State<GradebookScreen> {
                             );
                           },
                           onOpen: () => _openQuickGradeSheet(index),
+                          onMoveFocus: (direction) => _moveRapidScoreFocus(
+                            students: studentService.students,
+                            currentIndex: index,
+                            item: selectedGradeItem,
+                            direction: direction,
+                          ),
                         );
                       },
                     ),
@@ -1626,12 +1707,14 @@ class _ScoreEntryRow extends StatefulWidget {
   final String? seatNo;
   final String? photoBase64;
   final TextEditingController controller;
+  final FocusNode focusNode;
   final String gradeItemId;
   final double maxScore;
   final double? initialScore;
   final _ScoreCommitCallback onCommit;
   final Future<void> Function() onClear;
   final VoidCallback onOpen;
+  final Future<bool> Function(int direction) onMoveFocus;
 
   const _ScoreEntryRow({
     super.key,
@@ -1640,12 +1723,14 @@ class _ScoreEntryRow extends StatefulWidget {
     this.seatNo,
     this.photoBase64,
     required this.controller,
+    required this.focusNode,
     required this.gradeItemId,
     required this.maxScore,
     required this.initialScore,
     required this.onCommit,
     required this.onClear,
     required this.onOpen,
+    required this.onMoveFocus,
   });
 
   @override
@@ -1653,17 +1738,22 @@ class _ScoreEntryRow extends StatefulWidget {
 }
 
 class _ScoreEntryRowState extends State<_ScoreEntryRow> {
-  late final FocusNode _focusNode = FocusNode();
+  bool _skipNextBlurCommit = false;
 
   @override
   void initState() {
     super.initState();
+    widget.focusNode.addListener(_handleScoreFocusChange);
     _syncController(force: true);
   }
 
   @override
   void didUpdateWidget(covariant _ScoreEntryRow oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.focusNode != widget.focusNode) {
+      oldWidget.focusNode.removeListener(_handleScoreFocusChange);
+      widget.focusNode.addListener(_handleScoreFocusChange);
+    }
     if (oldWidget.initialScore != widget.initialScore ||
         oldWidget.gradeItemId != widget.gradeItemId ||
         oldWidget.controller != widget.controller) {
@@ -1673,18 +1763,35 @@ class _ScoreEntryRowState extends State<_ScoreEntryRow> {
 
   @override
   void dispose() {
-    _focusNode.dispose();
+    widget.focusNode.removeListener(_handleScoreFocusChange);
     super.dispose();
   }
 
+  void _handleScoreFocusChange() {
+    if (widget.focusNode.hasFocus) return;
+    if (_skipNextBlurCommit) {
+      _skipNextBlurCommit = false;
+      return;
+    }
+    widget.onCommit(showValidationMessage: true);
+  }
+
   void _syncController({bool force = false}) {
-    if (!force && _focusNode.hasFocus) return;
+    if (!force && widget.focusNode.hasFocus) return;
     final next = _scoreFieldText(widget.initialScore);
     if (widget.controller.text == next) return;
     widget.controller.value = TextEditingValue(
       text: next,
       selection: TextSelection.collapsed(offset: next.length),
     );
+  }
+
+  Future<void> _commitAndMove(int direction) async {
+    await widget.onCommit(showValidationMessage: true);
+    if (!mounted) return;
+    _skipNextBlurCommit = true;
+    final moved = await widget.onMoveFocus(direction);
+    if (!moved) _skipNextBlurCommit = false;
   }
 
   double _sliderValue(double max) {
@@ -1762,15 +1869,28 @@ class _ScoreEntryRowState extends State<_ScoreEntryRow> {
 
             final input = SizedBox(
               width: narrow ? double.infinity : 128,
-              child: Focus(
-                focusNode: _focusNode,
-                onFocusChange: (hasFocus) {
-                  if (!hasFocus) {
-                    widget.onCommit(showValidationMessage: true);
-                  }
+              child: CallbackShortcuts(
+                bindings: {
+                  const SingleActivator(LogicalKeyboardKey.enter): () =>
+                      _commitAndMove(1),
+                  const SingleActivator(LogicalKeyboardKey.numpadEnter): () =>
+                      _commitAndMove(1),
+                  const SingleActivator(
+                    LogicalKeyboardKey.enter,
+                    shift: true,
+                  ): () => _commitAndMove(-1),
+                  const SingleActivator(
+                    LogicalKeyboardKey.numpadEnter,
+                    shift: true,
+                  ): () => _commitAndMove(-1),
+                  const SingleActivator(LogicalKeyboardKey.arrowDown): () =>
+                      _commitAndMove(1),
+                  const SingleActivator(LogicalKeyboardKey.arrowUp): () =>
+                      _commitAndMove(-1),
                 },
                 child: TextField(
                   controller: widget.controller,
+                  focusNode: widget.focusNode,
                   textAlign: TextAlign.end,
                   textInputAction: TextInputAction.next,
                   decoration: _gradebookFieldDecoration(
@@ -1794,8 +1914,7 @@ class _ScoreEntryRowState extends State<_ScoreEntryRow> {
                     );
                   },
                   onSubmitted: (_) {
-                    widget.onCommit(showValidationMessage: true);
-                    FocusScope.of(context).nextFocus();
+                    _commitAndMove(1);
                   },
                   onTapOutside: (_) => widget.onCommit(
                     showValidationMessage: true,

--- a/lib/screens/gradebook_screen.dart
+++ b/lib/screens/gradebook_screen.dart
@@ -50,6 +50,7 @@ class _GradebookScreenState extends State<GradebookScreen> {
   final Map<String, FocusNode> _scoreFocusNodes = {};
   final Map<String, GlobalKey> _scoreRowKeys = {};
   final Set<String> _autoEnsuredCategories = <String>{};
+  int? _activeRowIndex;
 
   Future<bool> _confirmLeaveIfSaving() async {
     final scores = context.read<StudentScoreService>();
@@ -994,7 +995,7 @@ class _GradebookScreenState extends State<GradebookScreen> {
                   WorkspaceSectionHeader(
                     title: 'Student scores',
                     subtitle:
-                        'Rapid entry: Enter moves to next student. Arrow keys move through score fields.',
+                        'Click a row or use Enter / Arrow keys to move through scores',
                     subtitleMaxLines: 1,
                     action: FilledButton.tonalIcon(
                       onPressed: studentService.students.isEmpty
@@ -1065,6 +1066,12 @@ class _GradebookScreenState extends State<GradebookScreen> {
                             item: selectedGradeItem,
                             direction: direction,
                           ),
+                          isActive: index == _activeRowIndex,
+                          onBecameActive: () {
+                            if (_activeRowIndex != index) {
+                              setState(() => _activeRowIndex = index);
+                            }
+                          },
                         );
                       },
                     ),
@@ -1376,18 +1383,56 @@ class _GradebookFlatSurface extends StatelessWidget {
     required this.child,
     this.padding = const EdgeInsets.all(12),
     this.onTap,
+    this.isActive = false,
   });
 
   final Widget child;
   final EdgeInsetsGeometry padding;
   final VoidCallback? onTap;
+  final bool isActive;
 
   @override
   Widget build(BuildContext context) {
-    return WorkspaceFlatSurface(
+    final surface = WorkspaceFlatSurface(
       padding: padding,
       onTap: onTap,
       child: child,
+    );
+    if (!isActive) return surface;
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    return Stack(
+      children: [
+        surface,
+        Positioned.fill(
+          child: IgnorePointer(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary.withValues(
+                  alpha: isDark ? 0.08 : 0.07,
+                ),
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+          ),
+        ),
+        Positioned(
+          left: 0,
+          top: 0,
+          bottom: 0,
+          child: IgnorePointer(
+            child: Container(
+              width: 3,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary.withValues(alpha: 0.75),
+                borderRadius: const BorderRadius.horizontal(
+                  right: Radius.circular(1.5),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }
@@ -1715,6 +1760,8 @@ class _ScoreEntryRow extends StatefulWidget {
   final Future<void> Function() onClear;
   final VoidCallback onOpen;
   final Future<bool> Function(int direction) onMoveFocus;
+  final bool isActive;
+  final VoidCallback onBecameActive;
 
   const _ScoreEntryRow({
     super.key,
@@ -1731,6 +1778,8 @@ class _ScoreEntryRow extends StatefulWidget {
     required this.onClear,
     required this.onOpen,
     required this.onMoveFocus,
+    this.isActive = false,
+    required this.onBecameActive,
   });
 
   @override
@@ -1768,7 +1817,10 @@ class _ScoreEntryRowState extends State<_ScoreEntryRow> {
   }
 
   void _handleScoreFocusChange() {
-    if (widget.focusNode.hasFocus) return;
+    if (widget.focusNode.hasFocus) {
+      widget.onBecameActive();
+      return;
+    }
     if (_skipNextBlurCommit) {
       _skipNextBlurCommit = false;
       return;
@@ -1827,6 +1879,7 @@ class _ScoreEntryRowState extends State<_ScoreEntryRow> {
       container: true,
       label: rowLabel,
       child: _GradebookFlatSurface(
+        isActive: widget.isActive,
         padding: const EdgeInsets.fromLTRB(14, 10, 12, 10),
         child: LayoutBuilder(
           builder: (context, constraints) {
@@ -1867,6 +1920,10 @@ class _ScoreEntryRowState extends State<_ScoreEntryRow> {
               ],
             );
 
+            final activeFieldBorder = theme.colorScheme.primary.withValues(
+              alpha: theme.brightness == Brightness.dark ? 0.56 : 0.44,
+            );
+
             final input = SizedBox(
               width: narrow ? double.infinity : 128,
               child: CallbackShortcuts(
@@ -1888,36 +1945,60 @@ class _ScoreEntryRowState extends State<_ScoreEntryRow> {
                   const SingleActivator(LogicalKeyboardKey.arrowUp): () =>
                       _commitAndMove(-1),
                 },
-                child: TextField(
-                  controller: widget.controller,
-                  focusNode: widget.focusNode,
-                  textAlign: TextAlign.end,
-                  textInputAction: TextInputAction.next,
-                  decoration: _gradebookFieldDecoration(
-                    context,
-                    labelText: 'Score',
-                    suffixText: '/ ${_formatGradebookScore(max)}',
-                  ),
-                  keyboardType:
-                      const TextInputType.numberWithOptions(decimal: true),
-                  inputFormatters: [
-                    FilteringTextInputFormatter.allow(
-                      RegExp(r'^\d*\.?\d*'),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 140),
+                  curve: Curves.easeOutCubic,
+                  padding: widget.isActive
+                      ? const EdgeInsets.symmetric(horizontal: 1, vertical: 1)
+                      : EdgeInsets.zero,
+                  decoration: widget.isActive
+                      ? BoxDecoration(
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(color: activeFieldBorder),
+                          boxShadow: [
+                            BoxShadow(
+                              color: theme.colorScheme.primary.withValues(
+                                alpha: theme.brightness == Brightness.dark
+                                    ? 0.16
+                                    : 0.10,
+                              ),
+                              blurRadius: 8,
+                              spreadRadius: 0.5,
+                            ),
+                          ],
+                        )
+                      : null,
+                  child: TextField(
+                    controller: widget.controller,
+                    focusNode: widget.focusNode,
+                    textAlign: TextAlign.end,
+                    textInputAction: TextInputAction.next,
+                    decoration: _gradebookFieldDecoration(
+                      context,
+                      labelText: 'Score',
+                      suffixText: '/ ${_formatGradebookScore(max)}',
                     ),
-                  ],
-                  onTap: () {
-                    final text = widget.controller.text;
-                    if (text.isEmpty) return;
-                    widget.controller.selection = TextSelection(
-                      baseOffset: 0,
-                      extentOffset: text.length,
-                    );
-                  },
-                  onSubmitted: (_) {
-                    _commitAndMove(1);
-                  },
-                  onTapOutside: (_) => widget.onCommit(
-                    showValidationMessage: true,
+                    keyboardType:
+                        const TextInputType.numberWithOptions(decimal: true),
+                    inputFormatters: [
+                      FilteringTextInputFormatter.allow(
+                        RegExp(r'^\d*\.?\d*'),
+                      ),
+                    ],
+                    onTap: () {
+                      final text = widget.controller.text;
+                      if (text.isEmpty) return;
+                      widget.controller.selection = TextSelection(
+                        baseOffset: 0,
+                        extentOffset: text.length,
+                      );
+                    },
+                    onSubmitted: (_) {
+                      _commitAndMove(1);
+                    },
+                    onTapOutside: (_) => widget.onCommit(
+                      showValidationMessage: true,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
Adds keyboard-first rapid score entry to the Gradebook student score list.

- Enter commits the current score and moves to the next student score field.
- ArrowDown moves to the next score field.
- ArrowUp moves to the previous score field.
- Shift+Enter moves to the previous score field.
- Focus movement skips sliders and row action buttons.
- Newly focused rows auto-scroll into view.
- Adds a subtle rapid-entry hint for teachers.

## Files changed
- lib/screens/gradebook_screen.dart

## Verification
Passed:
- flutter analyze
- flutter test
- flutter build web --release

Manual QA:
- /os/class/demo-class-1/gradebook
- Desktop 1440x900, dark mode
- Mobile 390x844, light mode
- Gradebook loads
- Score fields remain editable
- Enter commits and moves down
- ArrowDown moves down
- ArrowUp moves up
- Invalid 999 score is not saved and restores/preserves previous valid score
- Apply-to-all, Undo, and Clear score remain present
- No RenderFlex overflow logs
- No page errors

## Risk notes
Low risk. The change is local to the Gradebook screen and does not touch services, models, Firebase logic, routes, export/import, or OS shell layout.

Follow-up:
Add a dedicated Gradebook widget test for rapid-entry traversal after this behavior is confirmed in normal teaching use.