### PR TITLE
Add InstructOS product branding config

### DIFF
--- a/lib/config/gradeflow_product_config.dart
+++ b/lib/config/gradeflow_product_config.dart
@@ -1,9 +1,9 @@
+import 'package:gradeflow/config/instructos_branding.dart';
+
 class GradeFlowProductConfig {
-  static const String appName = 'GradeFlow';
-  static const String marketingTagline =
-      'Professional workflow operating system for teachers';
-  static const String defaultSchoolName =
-      'The Affiliated High School of Tunghai University';
+  static const String appName = InstructOSBranding.productName;
+  static const String marketingTagline = InstructOSBranding.productTagline;
+  static const String defaultSchoolName = InstructOSBranding.defaultSchoolName;
   static const String defaultAttendancePortalUrl =
       'https://fsis.hn.thu.edu.tw/csn1t/permain.asp';
 

--- a/lib/config/instructos_branding.dart
+++ b/lib/config/instructos_branding.dart
@@ -1,0 +1,8 @@
+class InstructOSBranding {
+  static const String productName = 'InstructOS';
+  static const String productShortName = 'I/OS';
+  static const String productTagline = 'One system. Every classroom workflow.';
+  static const String legacyName = 'GradeFlow';
+  static const String defaultSchoolName =
+      'The Affiliated High School of Tunghai University';
+}


### PR DESCRIPTION
## Summary
Adds a small, isolated InstructOS branding configuration slice.

- Adds `InstructOSBranding` constants.
- Updates `GradeFlowProductConfig` to source the user-facing app name, tagline, and default school name from those constants.
- Keeps existing internal file/class names unchanged.

## Scope guard
Allowed files only:
- `lib/config/instructos_branding.dart`
- `lib/config/gradeflow_product_config.dart`

Not included:
- No splash/loading changes
- No login changes
- No OS Home changes
- No dashboard changes
- No asset changes
- No dependency changes
- No route/Firebase/service/model/auth changes

## Verification
Reported locally:
- `flutter analyze`: passed
- `flutter test`: passed, 76 tests

## Notes
This is Slice 1 of the InstructOS recovery work. The larger safety branch remains separate and should not be merged wholesale.