### PR TITLE
Align InstructOS launch startup experience

### DIFF
--- a/lib/components/gradeflow_launch_experience.dart
+++ b/lib/components/gradeflow_launch_experience.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:gradeflow/components/animated_page_background.dart';
-import 'package:gradeflow/components/gradeflow_entry_motion.dart';
 import 'package:gradeflow/config/gradeflow_product_config.dart';
 import 'package:gradeflow/services/auth_service.dart';
 
@@ -85,28 +84,15 @@ class _GradeFlowLaunchExperience extends StatelessWidget {
     required this.auth,
   });
 
-  String _statusTitle() {
+  String _statusLine() {
     if (!auth.isInitialized && auth.isLoading) {
-      return 'Restoring session';
+      return 'Restoring your secure classroom workspace...';
     }
     if (!auth.isInitialized) {
-      return 'Preparing workspace';
+      return 'Preparing your classroom workspace...';
     }
     if (auth.isAuthenticated) {
-      return 'Workspace ready';
-    }
-    return 'Ready to enter';
-  }
-
-  String _statusDetail() {
-    if (!auth.isInitialized && auth.isLoading) {
-      return 'Checking your secure GradeFlow session.';
-    }
-    if (!auth.isInitialized) {
-      return 'Bringing classroom tools online.';
-    }
-    if (auth.isAuthenticated) {
-      return 'Your teaching OS is ready.';
+      return 'Workspace ready. Opening ${GradeFlowProductConfig.appName}...';
     }
     return 'Secure access is ready.';
   }
@@ -119,8 +105,7 @@ class _GradeFlowLaunchExperience extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
-    final primary = theme.colorScheme.primary;
+    final progress = _progressValue();
 
     return Scaffold(
       backgroundColor: const Color(0xFF050912),
@@ -128,8 +113,7 @@ class _GradeFlowLaunchExperience extends StatelessWidget {
         child: LayoutBuilder(
           builder: (context, constraints) {
             final compact = constraints.maxWidth < 640;
-            final edgePadding = compact ? 18.0 : 28.0;
-            final panelPadding = compact ? 24.0 : 34.0;
+            final edgePadding = compact ? 20.0 : 32.0;
 
             return SingleChildScrollView(
               padding: EdgeInsets.all(edgePadding),
@@ -142,157 +126,41 @@ class _GradeFlowLaunchExperience extends StatelessWidget {
                 ),
                 child: Center(
                   child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 720),
-                    child: DecoratedBox(
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(compact ? 28 : 34),
-                        border: Border.all(
-                          color: Colors.white
-                              .withValues(alpha: isDark ? 0.11 : 0.20),
-                        ),
-                        gradient: LinearGradient(
-                          begin: Alignment.topLeft,
-                          end: Alignment.bottomRight,
-                          colors: [
-                            theme.colorScheme.surface.withValues(
-                              alpha: isDark ? 0.78 : 0.94,
+                    constraints: const BoxConstraints(maxWidth: 620),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: [
+                        _LaunchTextLockup(compact: compact),
+                        const SizedBox(height: 16),
+                        ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 460),
+                          child: Text(
+                            GradeFlowProductConfig.marketingTagline,
+                            textAlign: TextAlign.center,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                              height: 1.4,
+                              fontWeight: FontWeight.w500,
                             ),
-                            theme.colorScheme.surfaceContainerHighest
-                                .withValues(
-                              alpha: isDark ? 0.60 : 0.80,
-                            ),
-                          ],
-                        ),
-                        boxShadow: [
-                          BoxShadow(
-                            color: theme.shadowColor.withValues(
-                              alpha: isDark ? 0.42 : 0.13,
-                            ),
-                            blurRadius: 52,
-                            offset: const Offset(0, 26),
                           ),
-                        ],
-                      ),
-                      child: Padding(
-                        padding: EdgeInsets.all(panelPadding),
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: [
-                            const GradeFlowEntryMotion(size: 178),
-                            const SizedBox(height: 18),
-                            Text(
-                              'Teacher Operating System'.toUpperCase(),
-                              textAlign: TextAlign.center,
-                              style: theme.textTheme.labelLarge?.copyWith(
-                                color: theme.colorScheme.primary,
-                                letterSpacing: 1.2,
-                                fontWeight: FontWeight.w800,
-                              ),
-                            ),
-                            const SizedBox(height: 10),
-                            Text(
-                              GradeFlowProductConfig.appName,
-                              textAlign: TextAlign.center,
-                              style: theme.textTheme.headlineMedium?.copyWith(
-                                fontWeight: FontWeight.w900,
-                                letterSpacing: 0,
-                              ),
-                            ),
-                            const SizedBox(height: 8),
-                            ConstrainedBox(
-                              constraints: const BoxConstraints(maxWidth: 430),
-                              child: Text(
-                                'Opening the workspace for today\'s classes.',
-                                textAlign: TextAlign.center,
-                                style: theme.textTheme.bodyLarge?.copyWith(
-                                  color: theme.colorScheme.onSurfaceVariant,
-                                  height: 1.45,
-                                ),
-                              ),
-                            ),
-                            const SizedBox(height: 26),
-                            Container(
-                              padding: EdgeInsets.all(compact ? 16 : 18),
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(22),
-                                color: Colors.white.withValues(
-                                  alpha: isDark ? 0.045 : 0.56,
-                                ),
-                                border: Border.all(
-                                  color: Colors.white.withValues(
-                                    alpha: isDark ? 0.08 : 0.20,
-                                  ),
-                                ),
-                              ),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Row(
-                                    children: [
-                                      Expanded(
-                                        child: Text(
-                                          _statusTitle(),
-                                          style: theme.textTheme.titleLarge
-                                              ?.copyWith(
-                                            fontWeight: FontWeight.w800,
-                                            letterSpacing: 0,
-                                          ),
-                                        ),
-                                      ),
-                                      _LaunchStageChip(
-                                        label: auth.isInitialized
-                                            ? 'Online'
-                                            : 'Starting',
-                                      ),
-                                    ],
-                                  ),
-                                  const SizedBox(height: 6),
-                                  Text(
-                                    _statusDetail(),
-                                    style: theme.textTheme.bodyMedium?.copyWith(
-                                      color: theme.colorScheme.onSurfaceVariant,
-                                      height: 1.5,
-                                    ),
-                                  ),
-                                  const SizedBox(height: 18),
-                                  ClipRRect(
-                                    borderRadius: BorderRadius.circular(999),
-                                    child: LinearProgressIndicator(
-                                      value: _progressValue(),
-                                      minHeight: 6,
-                                      backgroundColor:
-                                          Colors.white.withValues(alpha: 0.08),
-                                      valueColor: AlwaysStoppedAnimation<Color>(
-                                        primary.withValues(alpha: 0.95),
-                                      ),
-                                    ),
-                                  ),
-                                  const SizedBox(height: 16),
-                                  Wrap(
-                                    spacing: 8,
-                                    runSpacing: 8,
-                                    children: [
-                                      const _LaunchChecklistItem(
-                                        label: 'Secure session',
-                                        active: true,
-                                      ),
-                                      const _LaunchChecklistItem(
-                                        label: 'Classroom tools',
-                                        active: true,
-                                      ),
-                                      _LaunchChecklistItem(
-                                        label: 'Workspace ready',
-                                        active: auth.isInitialized,
-                                      ),
-                                    ],
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
                         ),
-                      ),
+                        const SizedBox(height: 26),
+                        _LaunchProgressLine(value: progress),
+                        const SizedBox(height: 14),
+                        ConstrainedBox(
+                          constraints: const BoxConstraints(maxWidth: 460),
+                          child: Text(
+                            _statusLine(),
+                            textAlign: TextAlign.center,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant
+                                  .withValues(alpha: 0.92),
+                              height: 1.45,
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
                   ),
                 ),
@@ -305,74 +173,118 @@ class _GradeFlowLaunchExperience extends StatelessWidget {
   }
 }
 
-class _LaunchStageChip extends StatelessWidget {
-  final String label;
+class _LaunchTextLockup extends StatelessWidget {
+  const _LaunchTextLockup({required this.compact});
 
-  const _LaunchStageChip({
-    required this.label,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(999),
-        color: Colors.white.withValues(alpha: 0.05),
-        border: Border.all(
-          color: Colors.white.withValues(alpha: 0.10),
-        ),
-      ),
-      child: Text(
-        label,
-        style: Theme.of(context).textTheme.labelMedium?.copyWith(
-              fontWeight: FontWeight.w700,
-            ),
-      ),
-    );
-  }
-}
-
-class _LaunchChecklistItem extends StatelessWidget {
-  const _LaunchChecklistItem({
-    required this.label,
-    required this.active,
-  });
-
-  final String label;
-  final bool active;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final color = active
-        ? theme.colorScheme.primary
-        : theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.78);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(999),
-        color: color.withValues(alpha: active ? 0.12 : 0.06),
-        border: Border.all(color: color.withValues(alpha: 0.18)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            active ? Icons.check_circle_outline : Icons.radio_button_unchecked,
-            size: 15,
-            color: color,
-          ),
-          const SizedBox(width: 7),
-          Text(
-            label,
-            style: theme.textTheme.labelMedium?.copyWith(
-              color: color,
-              fontWeight: FontWeight.w800,
-              letterSpacing: 0,
+    final symbolSize = compact ? 34.0 : 42.0;
+    final nameSize = compact ? 34.0 : 44.0;
+    final symbolStyle = theme.textTheme.headlineMedium?.copyWith(
+          fontSize: symbolSize,
+          fontWeight: FontWeight.w700,
+          height: 1.0,
+          letterSpacing: -0.3,
+          color: theme.colorScheme.onSurface,
+        ) ??
+        TextStyle(
+          fontSize: symbolSize,
+          fontWeight: FontWeight.w700,
+          height: 1.0,
+          letterSpacing: -0.3,
+          color: theme.colorScheme.onSurface,
+        );
+
+    final nameStyle = theme.textTheme.displaySmall?.copyWith(
+          fontSize: nameSize,
+          fontWeight: FontWeight.w700,
+          height: 1.0,
+          letterSpacing: -0.4,
+          color: theme.colorScheme.onSurface,
+        ) ??
+        TextStyle(
+          fontSize: nameSize,
+          fontWeight: FontWeight.w700,
+          height: 1.0,
+          letterSpacing: -0.4,
+          color: theme.colorScheme.onSurface,
+        );
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('I', style: symbolStyle),
+            Text(
+              '/',
+              style: symbolStyle.copyWith(
+                color: const Color(0xFF2A6BFF),
+              ),
             ),
-          ),
-        ],
+            Text(
+              'OS',
+              style: symbolStyle.copyWith(
+                color: const Color(0xFF22D3EE),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        Text(
+          GradeFlowProductConfig.appName,
+          style: nameStyle,
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}
+
+class _LaunchProgressLine extends StatelessWidget {
+  const _LaunchProgressLine({required this.value});
+
+  final double value;
+
+  @override
+  Widget build(BuildContext context) {
+    final trackColor = Colors.white.withValues(alpha: 0.12);
+    final clamped = value.clamp(0.0, 1.0);
+
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 280),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final width = constraints.maxWidth;
+          return Stack(
+            children: [
+              Container(
+                height: 3,
+                width: width,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(999),
+                  color: trackColor,
+                ),
+              ),
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeOutCubic,
+                height: 3,
+                width: width * clamped,
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(999),
+                  gradient: const LinearGradient(
+                    colors: [Color(0xFF5C88FF), Color(0xFF22D3EE)],
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/web/index.html
+++ b/web/index.html
@@ -94,22 +94,22 @@
 
     .gf-loader-shell {
       position: relative;
-      width: min(100%, 500px);
+      width: min(100%, 520px);
       padding: 28px;
       border-radius: 28px;
       border: 1px solid var(--gf-border);
-      background:
-        linear-gradient(145deg, rgba(17, 27, 40, 0.92), rgba(11, 18, 28, 0.82));
+      background: linear-gradient(145deg, rgba(17, 27, 40, 0.9), rgba(11, 18, 28, 0.8));
       box-shadow:
         0 24px 64px rgba(0, 0, 0, 0.38),
         inset 0 1px 0 rgba(255, 255, 255, 0.06);
       overflow: hidden;
+      text-align: center;
     }
 
     .gf-loader-shell::before {
       content: "";
       position: absolute;
-      inset: auto -64px -96px auto;
+      inset: auto -72px -108px auto;
       width: 220px;
       height: 220px;
       border-radius: 50%;
@@ -118,83 +118,51 @@
     }
 
     .gf-loader-head {
-      display: flex;
-      align-items: flex-start;
-      gap: 16px;
+      display: grid;
+      justify-items: center;
+      gap: 12px;
     }
 
-    .gf-loader-mark {
-      position: relative;
-      width: 72px;
-      height: 72px;
-      border-radius: 22px;
-      background: linear-gradient(145deg, var(--gf-accent), var(--gf-cyan));
-      box-shadow: 0 16px 34px rgba(92, 136, 255, 0.3);
-      flex: 0 0 auto;
+    .gf-loader-lockup {
+      display: inline-flex;
+      align-items: baseline;
+      gap: 2px;
+      font-size: clamp(1.9rem, 3.5vw, 2.4rem);
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      line-height: 1;
     }
 
-    .gf-loader-mark::before,
-    .gf-loader-mark::after {
-      content: "";
-      position: absolute;
-      inset: 14px;
-      border-radius: 16px;
-      border: 1px solid rgba(255, 255, 255, 0.24);
+    .gf-loader-lockup-slash {
+      color: var(--gf-accent);
     }
 
-    .gf-loader-mark::after {
-      inset: 24px;
-      border-radius: 12px;
-      background: rgba(255, 255, 255, 0.14);
-      border: 0;
+    .gf-loader-lockup-os {
+      color: var(--gf-cyan);
     }
 
     .gf-loader-title {
       margin: 0;
-      font-size: clamp(1.8rem, 3vw, 2.4rem);
+      font-size: clamp(2rem, 4vw, 2.75rem);
       font-weight: 800;
       letter-spacing: -0.04em;
-    }
-
-    .gf-loader-kicker {
-      margin: 0 0 10px;
-      color: var(--gf-muted);
-      font-size: 0.86rem;
-      font-weight: 700;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
+      line-height: 1.05;
     }
 
     .gf-loader-copy {
-      margin: 8px 0 0;
+      margin: 2px auto 0;
       color: var(--gf-muted);
-      line-height: 1.55;
+      line-height: 1.5;
       max-width: 34rem;
-    }
-
-    .gf-loader-row {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px;
-      margin-top: 24px;
-    }
-
-    .gf-loader-pill {
-      padding: 9px 12px;
-      border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.08);
-      background: rgba(255, 255, 255, 0.04);
-      color: var(--gf-text);
-      font-size: 0.88rem;
-      font-weight: 700;
+      font-size: clamp(0.95rem, 2vw, 1.06rem);
     }
 
     .gf-loader-progress {
       position: relative;
-      height: 6px;
+      height: 3px;
       margin-top: 24px;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.08);
+      background: rgba(255, 255, 255, 0.14);
       overflow: hidden;
     }
 
@@ -202,7 +170,7 @@
       content: "";
       position: absolute;
       inset: 0;
-      width: 42%;
+      width: 36%;
       border-radius: inherit;
       background: linear-gradient(90deg, var(--gf-accent), var(--gf-cyan));
       box-shadow: 0 0 18px rgba(92, 136, 255, 0.28);
@@ -210,22 +178,12 @@
     }
 
     .gf-loader-status {
-      display: flex;
-      align-items: center;
-      gap: 10px;
+      display: block;
       margin-top: 18px;
       color: var(--gf-muted);
       font-size: 0.9rem;
-      font-weight: 600;
-    }
-
-    .gf-loader-status-dot {
-      width: 10px;
-      height: 10px;
-      border-radius: 50%;
-      background: var(--gf-cyan);
-      box-shadow: 0 0 18px rgba(70, 198, 233, 0.5);
-      animation: gradeflow-pulse 1.6s ease-in-out infinite;
+      font-weight: 500;
+      line-height: 1.4;
     }
 
     @keyframes gradeflow-loader {
@@ -240,18 +198,6 @@
       }
     }
 
-    @keyframes gradeflow-pulse {
-      0%,
-      100% {
-        opacity: 0.5;
-        transform: scale(0.92);
-      }
-      50% {
-        opacity: 1;
-        transform: scale(1.08);
-      }
-    }
-
     @media (max-width: 640px) {
       .gf-loader-shell {
         padding: 22px;
@@ -259,12 +205,7 @@
       }
 
       .gf-loader-head {
-        flex-direction: column;
-      }
-
-      .gf-loader-mark {
-        width: 64px;
-        height: 64px;
+        gap: 10px;
       }
     }
   </style>
@@ -273,25 +214,14 @@
   <div id="gradeflow-loader" aria-hidden="true">
     <div class="gf-loader-shell">
       <div class="gf-loader-head">
-        <div class="gf-loader-mark"></div>
-        <div>
-          <p class="gf-loader-kicker">Teacher Operating System</p>
-          <h1 class="gf-loader-title">GradeFlow</h1>
-          <p class="gf-loader-copy">
-            Opening the workspace for today’s classes.
-          </p>
+        <div class="gf-loader-lockup" aria-hidden="true">
+          <span>I</span><span class="gf-loader-lockup-slash">/</span><span class="gf-loader-lockup-os">OS</span>
         </div>
-      </div>
-      <div class="gf-loader-row">
-        <div class="gf-loader-pill">Secure session</div>
-        <div class="gf-loader-pill">Classroom tools</div>
-        <div class="gf-loader-pill">Workspace ready</div>
+        <h1 class="gf-loader-title">InstructOS</h1>
+        <p class="gf-loader-copy">One system. Every classroom workflow.</p>
       </div>
       <div class="gf-loader-progress"></div>
-      <div class="gf-loader-status">
-        <span class="gf-loader-status-dot"></span>
-        Preparing GradeFlow
-      </div>
+      <p class="gf-loader-status">Preparing your classroom workspace...</p>
     </div>
   </div>
   <script>
@@ -328,7 +258,7 @@
 
       window.setTimeout(() => {
         if (!removed && status) {
-          status.lastChild.textContent = ' Still preparing GradeFlow';
+          status.textContent = 'Still preparing your classroom workspace...';
         }
       }, 45000);
     })();


### PR DESCRIPTION
## Summary
Aligns the pre-Flutter web startup loader and Flutter launch gate so the first visible startup experience consistently uses the InstructOS identity.

- Updates the Flutter launch experience to a calmer text-only InstructOS / I/OS lockup.
- Updates `web/index.html` so the static pre-Flutter loader no longer shows the old GradeFlow checklist.
- Keeps the launch/startup slice dependency-free and asset-free.

## Files changed
- `lib/components/gradeflow_launch_experience.dart`
- `web/index.html`

## Scope guard
Not included:
- No login screen changes
- No OS Home changes
- No dashboard changes
- No route/auth/Firebase/service/model changes
- No `pubspec.yaml` or dependency changes
- No branding assets added
- No `e2e/helpers.ts` changes
- PR #21 safety/recovery draft was not touched

## Verification
Reported locally:
- `flutter analyze`: passed
- `flutter test`: passed, 76 tests
- `flutter build web --release --no-wasm-dry-run`: passed

## Visual QA
Reported locally from release build served via `build/web`:
- Desktop startup loader shows `I / OS`, `InstructOS`, and `One system. Every classroom workflow.`
- Mobile startup loader shows the same InstructOS startup language.
- Old GradeFlow checklist loader no longer appears.
- Static HTML loader and Flutter launch gate now visually align.
- App transitions normally into the login/app surface.

## Notes
This is Slice 2 of the controlled InstructOS recovery. Login visual consistency should be handled as the next separate slice.