### PR TITLE
Align visible shell branding to InstructOS

### DIFF
--- a/lib/os/os_assistant.dart
+++ b/lib/os/os_assistant.dart
@@ -1,4 +1,4 @@
-/// GradeFlow OS — AI Assistant Entry
+﻿/// GradeFlow OS — AI Assistant Entry
 ///
 /// [OSAssistantFab] is the always-visible floating AI orb button.
 /// [OSAssistantPanel] is the slide-up panel with suggested actions
@@ -199,7 +199,7 @@ class _AssistantHeader extends StatelessWidget {
           ),
           const SizedBox(width: 10),
           Text(
-            'GradeFlow Assistant',
+            'InstructOS Assistant',
             style: TextStyle(
               fontSize: 14,
               fontWeight: FontWeight.w700,

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -1,4 +1,4 @@
-// GradeFlow OS — Home Surface
+﻿// GradeFlow OS — Home Surface
 //
 // The teacher's primary landing surface should read like an actual OS home:
 // a desktop stage, pinned apps, glanceable live signals, and secondary
@@ -1962,7 +1962,7 @@ class _HomeSystemStrip extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        'GradeFlow OS',
+                        'InstructOS',
                         style: TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.w700,
@@ -2086,7 +2086,7 @@ class _HomeSystemStrip extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       Text(
-                        'GradeFlow OS',
+                        'InstructOS',
                         style: TextStyle(
                           fontSize: 15,
                           fontWeight: FontWeight.w700,
@@ -2243,7 +2243,7 @@ class _HomeSchoolIdentity extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      'GradeFlow OS',
+                      'InstructOS',
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(

--- a/lib/os/surfaces/planner_surface.dart
+++ b/lib/os/surfaces/planner_surface.dart
@@ -995,7 +995,7 @@ class _PlannerSidebar extends StatelessWidget {
           ),
           const Spacer(),
           Text(
-            'GradeFlow OS',
+            'InstructOS',
             style: TextStyle(
               fontWeight: FontWeight.w900,
               fontSize: 20,

--- a/lib/repositories/communication_repository.dart
+++ b/lib/repositories/communication_repository.dart
@@ -194,7 +194,7 @@ List<CommunicationMessage> buildDefaultCommunicationMessages(User user) {
     ),
     message(
       channelId: 'all-staff',
-      authorName: 'GradeFlow Team',
+      authorName: 'InstructOS Team',
       role: CommunicationRole.admin,
       text:
           'All-staff is ready for quick questions, coverage notes, and short daily coordination.',
@@ -202,7 +202,7 @@ List<CommunicationMessage> buildDefaultCommunicationMessages(User user) {
     ),
     message(
       channelId: 'teaching-team',
-      authorName: 'GradeFlow Team',
+      authorName: 'InstructOS Team',
       role: CommunicationRole.departmentLead,
       text:
           'Teaching team can hold department planning, intervention follow-up, and shared support notes.',
@@ -210,7 +210,7 @@ List<CommunicationMessage> buildDefaultCommunicationMessages(User user) {
     ),
     message(
       channelId: 'shared-files',
-      authorName: 'GradeFlow Team',
+      authorName: 'InstructOS Team',
       role: CommunicationRole.admin,
       text:
           'Shared files is the right place for pinned resources and follow-up documents once attachments are connected.',


### PR DESCRIPTION
## Summary
Aligns remaining visible shell branding from GradeFlow to InstructOS.

- Updates OS Home visible shell labels from `GradeFlow OS` to `InstructOS`.
- Updates Planner visible sidebar branding from `GradeFlow OS` to `InstructOS`.
- Updates assistant header from `GradeFlow Assistant` to `InstructOS Assistant`.
- Updates visible seeded communication authors from `GradeFlow Team` to `InstructOS Team`.

## Files changed
- `lib/os/surfaces/home_surface.dart`
- `lib/os/surfaces/planner_surface.dart`
- `lib/os/os_assistant.dart`
- `lib/repositories/communication_repository.dart`

## Scope guard
Not included:
- No route changes
- No auth/Firebase/service/model changes
- No layout or styling changes
- No file/class renames
- No dependency changes
- No visual QA screenshots or build output
- PR #21 was not touched

## Verification
Reported locally:
- `flutter analyze`: passed
- `flutter test`: passed, 76 tests
- `flutter build web --release --no-wasm-dry-run`: passed

## Visual QA
Reported locally:
- OS Home header shows `InstructOS`.
- Assistant panel shows `InstructOS Assistant`.
- Planner has no visible GradeFlow label at tested width.
- Messages/seeded communication author text updated to `InstructOS Team`.
- No mobile layout regression observed.

## Notes
This is Slice 3 of the controlled InstructOS recovery. It is text-only and keeps implementation names such as `GradeFlowOSShell` and `GradeFlowProductConfig` unchanged for now.