### PR TITLE
Fix mobile OS Home dock spacing

### DIFF
--- a/lib/os/gradeflow_os_shell.dart
+++ b/lib/os/gradeflow_os_shell.dart
@@ -132,7 +132,7 @@ class _GradeFlowOSShellState extends State<GradeFlowOSShell> {
     // Reserve dock space so routed content is not obscured.
     final dockReserve = widget.teachMode
         ? 0.0
-        : OSSpacing.dockHeight + OSSpacing.dockBottomMargin + 8;
+        : OSSpacing.dockHeight + OSSpacing.dockBottomMargin;
 
     final adjustedMQ = mq.copyWith(
       padding: mq.padding.copyWith(
@@ -167,17 +167,14 @@ class _GradeFlowOSShellState extends State<GradeFlowOSShell> {
             left: 0,
             right: 0,
             bottom: 0,
-            child: SafeArea(
-              top: false,
-              child: Padding(
-                padding: EdgeInsets.only(
-                  bottom: OSSpacing.dockBottomMargin,
-                  left: isPhone ? 12 : 24,
-                  right: isPhone ? 12 : 24,
-                ),
-                child: Center(
-                  child: OSDock(teachMode: widget.teachMode),
-                ),
+            child: Padding(
+              padding: EdgeInsets.only(
+                bottom: mq.padding.bottom + OSSpacing.dockBottomMargin,
+                left: isPhone ? 12 : 24,
+                right: isPhone ? 12 : 24,
+              ),
+              child: Center(
+                child: OSDock(teachMode: widget.teachMode),
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
Fixes the mobile OS Home lower black/squeezed region by removing the dock double-reservation in `GradeFlowOSShell`.

- Keeps the explicit dock overlay placement.
- Removes the extra doubled bottom reservation caused by inflated descendant `MediaQuery` padding plus dock `SafeArea` handling.
- Keeps this as a narrow shell layout fix with no OS Home redesign.

## Files changed
- `lib/os/gradeflow_os_shell.dart`

## Scope guard
Not included:
- No OS Home redesign
- No duplicate-button cleanup
- No login changes
- No route/auth/Firebase/service/model changes
- No dependency changes
- No screenshots/tmp/build output
- PR #21 was not touched

## Verification
Reported locally:
- `flutter analyze`: passed
- `flutter test`: passed, 76 tests
- `flutter build web --release`: passed

## Visual QA
Reported locally:
- Mobile dock is now at the bottom of the viewport instead of mid-screen.
- Lower black/squeezed region is resolved.
- Dock remains visible and usable.

## Notes
This is Slice 4 of the controlled InstructOS recovery. The next separate slice should address OS Home action duplication / calm glass-folder workspace polish.