### PR TITLE
Stabilize InstructOS launch and section carry-forward flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GradeFlow
+# InstructOS
 
-GradeFlow is a web-first Flutter app for teacher workflow management. It brings together class lists, student rosters, grading, exports, classroom tools, and seating plans in one project.
+InstructOS is a web-first Flutter app for teacher workflow management. It brings together class lists, student rosters, grading, exports, classroom tools, and seating plans in one project.
 
 Built for The Affiliated High School of Tunghai University.
 
@@ -17,7 +17,7 @@ Built for The Affiliated High School of Tunghai University.
 
 ## Direction
 
-GradeFlow is currently strongest as a web app.
+InstructOS is currently strongest as a web app.
 
 - Web is the primary supported target
 - Android and iOS codepaths exist, but they should be treated as needing local SDK and device verification
@@ -34,7 +34,7 @@ Some dashboard and utility data is still stored locally even when Firebase is en
 
 ## Demo Mode
 
-Use the `Try Demo Account` button on the login screen to create and sign in with a seeded demo workspace.
+Use the `Open demo` button on the login screen to create and sign in with a seeded demo workspace.
 
 The demo flow now includes:
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.CAMERA" />
     <application
-        android:label="GradeFlow"
+        android:label="InstructOS"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,16 +1,38 @@
 # Playwright E2E
 
-Playwright auto-builds the Flutter web release and serves `build/web` in SPA mode while tests run.
-
-## Run
+Playwright auto-builds the Flutter web release and serves `build/web` in SPA
+mode while tests run. For faster local iteration, build once first and override
+the server command:
 
 ```pwsh
-cd c:\Dev\Gradeflow
-npm install
-npm run e2e
+$env:E2E_WEB_SERVER_COMMAND = "npx.cmd serve build/web -s -l 7357"
 ```
+
+## Release Gates
+
+```pwsh
+npm run e2e:smoke
+npm run e2e:routing
+npm run e2e:core
+```
+
+- `e2e:smoke` runs the cold unauthenticated login/demo smoke checks.
+- `e2e:routing` uses a one-time seeded demo auth state and checks shell/routing.
+- `e2e:core` runs routing plus primary workflow checks.
+
+## Non-Blocking Regression
+
+```pwsh
+npm run e2e:regression
+npm run e2e:full
+```
+
+These keep slower export, seating, dashboard trust, and reporting checks visible
+without making every small change wait on the whole suite.
 
 ## Notes
 
 - Default URL is `http://127.0.0.1:7357`.
-- Override port with `$env:PORT = "7357"` (or set `$env:BASE_URL`).
+- Override port with `$env:PORT = "7357"` or set `$env:BASE_URL`.
+- Gated commands use `playwright.gated.config.ts`, which creates
+  `test-results/.auth/demo-user.json` once per run.

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,19 @@
+import { test as setup, expect } from '@playwright/test';
+import {
+  ensureDemoSignedIn,
+  ensureFlutterSemantics,
+  expectDashboardShell,
+} from './helpers';
+
+const authFile = 'test-results/.auth/demo-user.json';
+
+setup('authenticate demo workspace', async ({ page }) => {
+  setup.setTimeout(240_000);
+
+  await page.goto('/');
+  await ensureFlutterSemantics(page);
+  await ensureDemoSignedIn(page);
+  await expect(page).toHaveURL(/(?:\/|\/#\/)(?:dashboard|os\/home)(?:[?#]|$)/);
+  await expectDashboardShell(page);
+  await page.context().storageState({ path: authFile });
+});

--- a/e2e/core_flow.spec.ts
+++ b/e2e/core_flow.spec.ts
@@ -97,7 +97,7 @@ async function reopenDemoClassGradebook(page: Page) {
   });
 }
 
-test("core loop: edit score persists; undo reverts", async ({ page }) => {
+test("@regression core loop: edit score persists; undo reverts", async ({ page }) => {
   test.setTimeout(360_000);
 
   await gotoRoot(page);

--- a/e2e/dashboard_class_trust.spec.ts
+++ b/e2e/dashboard_class_trust.spec.ts
@@ -82,7 +82,7 @@ async function selectClassToolsClass(page: Page, className: string) {
   ).toBeVisible({ timeout: 15_000 });
 }
 
-test('Fresh dashboard blocks class-target actions until a class is explicitly chosen', async ({
+test('@regression Fresh dashboard blocks class-target actions until a class is explicitly chosen', async ({
   page,
 }) => {
   test.setTimeout(180_000);
@@ -105,7 +105,7 @@ test('Fresh dashboard blocks class-target actions until a class is explicitly ch
   await expect(genericSeatingAction).toBeVisible();
 });
 
-test('Explicit dashboard class selection persists across refresh', async ({
+test('@regression Explicit dashboard class selection persists across refresh', async ({
   page,
 }) => {
   test.setTimeout(180_000);
@@ -124,7 +124,7 @@ test('Explicit dashboard class selection persists across refresh', async ({
   ).toBeVisible({ timeout: 60_000 });
 });
 
-test('Gradebook and Seating still open for the selected dashboard class', async ({
+test('@regression Gradebook and Seating still open for the selected dashboard class', async ({
   page,
 }) => {
   test.setTimeout(240_000);
@@ -144,7 +144,7 @@ test('Gradebook and Seating still open for the selected dashboard class', async 
   await expect(page.locator('body')).toContainText('Layouts: 1');
 });
 
-test('Export and Final Exam show the selected class clearly in-screen', async ({
+test('@regression Export and Final Exam show the selected class clearly in-screen', async ({
   page,
 }) => {
   test.setTimeout(240_000);
@@ -166,7 +166,7 @@ test('Export and Final Exam show the selected class clearly in-screen', async ({
   await expect(page.locator('body')).toContainText('Final Exam = 60% of total grade');
 });
 
-test('Class-tools seating, OS class cold-load, and OS home rail stay correct', async ({
+test('@regression Class-tools seating, OS class cold-load, and OS home rail stay correct', async ({
   page,
 }) => {
   test.setTimeout(240_000);

--- a/e2e/dashboard_os_shell.spec.ts
+++ b/e2e/dashboard_os_shell.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { ensureDemoSignedIn } from './helpers';
 
-test('dashboard attention center and dock stay available on desktop', async ({
+test('@routing dashboard attention center and dock stay available on desktop', async ({
   page,
 }) => {
   test.setTimeout(180_000);

--- a/e2e/features.spec.ts
+++ b/e2e/features.spec.ts
@@ -20,7 +20,7 @@ async function gotoDemoExport(page: import('@playwright/test').Page) {
   await gotoDemoClassRoute(page, 'export');
 }
 
-test('Export: grade export screen loads with actionable controls', async ({
+test('@core Export: grade export screen loads with actionable controls', async ({
   page,
 }) => {
   test.setTimeout(180_000);
@@ -33,7 +33,7 @@ test('Export: grade export screen loads with actionable controls', async ({
   await expect(page.getByRole('button', { name: /^Preview CSV$/i })).toBeVisible();
 });
 
-test('Export: browser export action shows download feedback', async ({ page }) => {
+test('@regression Export: browser export action shows download feedback', async ({ page }) => {
   test.setTimeout(180_000);
 
   await gotoRoot(page);
@@ -54,7 +54,7 @@ test('Export: browser export action shows download feedback', async ({ page }) =
   );
 });
 
-test('Export: CSV preview supports download action', async ({ page }) => {
+test('@regression Export: CSV preview supports download action', async ({ page }) => {
   test.setTimeout(180_000);
 
   await gotoRoot(page);
@@ -92,7 +92,7 @@ test('Export: CSV preview supports download action', async ({ page }) => {
   }
 });
 
-test('Export: PDF preview exposes download action', async ({ page }) => {
+test('@regression Export: PDF preview exposes download action', async ({ page }) => {
   test.setTimeout(180_000);
 
   await gotoRoot(page);
@@ -125,7 +125,7 @@ test('Export: PDF preview exposes download action', async ({ page }) => {
   await expect(page.getByRole('button', { name: /^Download PDF$/i })).toBeVisible();
 });
 
-test('Export: PDF preview close and reopen keeps download action available', async ({ page }) => {
+test('@regression Export: PDF preview close and reopen keeps download action available', async ({ page }) => {
   test.setTimeout(180_000);
 
   await gotoRoot(page);
@@ -155,8 +155,8 @@ test('Export: PDF preview close and reopen keeps download action available', asy
   await expect(page.getByRole('button', { name: /^Download PDF$/i })).toBeVisible();
 });
 
-test('Seating: editor and full screen flow loads', async ({ page }) => {
-  test.setTimeout(120_000);
+test('@regression Seating: editor and full screen flow loads', async ({ page }) => {
+  test.setTimeout(240_000);
 
   await gotoRoot(page);
   await ensureDemoSignedIn(page);
@@ -198,7 +198,7 @@ test('Seating: editor and full screen flow loads', async ({ page }) => {
   await expectSeatingSurface(page);
 });
 
-test('Seating: substitute handout preview supports download action', async ({
+test('@regression Seating: substitute handout preview supports download action', async ({
   page,
 }) => {
   test.setTimeout(180_000);
@@ -232,20 +232,20 @@ test('Seating: substitute handout preview supports download action', async ({
   }
 });
 
-test('Routing: direct navigation to classes works without refresh', async ({
+test('@routing Routing: direct navigation to classes works without refresh', async ({
   page,
 }) => {
-  test.setTimeout(120_000);
+  test.setTimeout(240_000);
 
   await page.goto('/');
   await ensureDemoSignedIn(page);
 
   await gotoClasses(page);
-  await expect(page).toHaveURL(new RegExp(`${classesPath.replace('/', '\\/')}(?:\\?|$)`));
+  await expect(page).toHaveURL(/(?:\/|\/#\/)classes(?:[?#]|$)/);
 });
 
-test('Dashboard: utility dock keeps schedule reachable', async ({ page }) => {
-  test.setTimeout(120_000);
+test('@routing Dashboard: utility rail keeps timetable reachable', async ({ page }) => {
+  test.setTimeout(240_000);
 
   await page.goto('/');
   await ensureDemoSignedIn(page);
@@ -253,12 +253,12 @@ test('Dashboard: utility dock keeps schedule reachable', async ({ page }) => {
   await gotoDashboard(page);
   await expectDashboardShell(page);
   await expect(
-    page.getByRole('button', { name: /^Schedule\b/i }).last(),
+    page.getByRole('button', { name: /^(Open timetable|Timetable\b)/i }).first(),
   ).toBeVisible();
 });
 
-test('Import: classes workspace opens source chooser', async ({ page }) => {
-  test.setTimeout(120_000);
+test('@core Import: classes workspace opens source chooser', async ({ page }) => {
+  test.setTimeout(240_000);
 
   await page.goto('/');
   await ensureDemoSignedIn(page);
@@ -278,10 +278,10 @@ test('Import: classes workspace opens source chooser', async ({ page }) => {
   ).toBeVisible();
 });
 
-test('Navigation: browser back returns from classes to dashboard', async ({
+test('@core Navigation: browser back returns from classes to dashboard', async ({
   page,
 }) => {
-  test.setTimeout(120_000);
+  test.setTimeout(240_000);
 
   await page.goto('/');
   await ensureDemoSignedIn(page);
@@ -291,12 +291,12 @@ test('Navigation: browser back returns from classes to dashboard', async ({
   await gotoClasses(page);
 
   await page.goBack();
-  await expect(page).toHaveURL(new RegExp(`${dashboardPath.replace('/', '\\/')}(?:\\?|$)`));
+  await expect(page).toHaveURL(/(?:\/|\/#\/)dashboard(?:[?#]|$)/);
   await expectDashboardShell(page);
 });
 
-test('Console: no critical errors during primary navigation', async ({ page }) => {
-  test.setTimeout(120_000);
+test('@regression Console: no critical errors during primary navigation', async ({ page }) => {
+  test.setTimeout(240_000);
 
   const errors: string[] = [];
 
@@ -313,7 +313,7 @@ test('Console: no critical errors during primary navigation', async ({ page }) =
   await gotoClasses(page);
 
   await gotoDemoClassRoute(page, 'seating');
-  await expect(page).toHaveURL(/\/class\/[^/]+\/seating(?:\?|$)/);
+  await expect(page).toHaveURL(/(?:\/|\/#\/)(?:os\/)?class\/[^/]+\/seating(?:[?#]|$)/);
 
   await page.goto(dashboardPath);
   await gotoDashboard(page);

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -120,7 +120,7 @@ export async function ensureDemoSignedIn(page: Page) {
       ],
       1_000,
     )) ||
-    /HOME STAGE|Planner|Class workspace|GradeFlow OS|Pinned apps|Class spaces/i.test(
+    /HOME STAGE|Planner|Class workspace|Pinned apps|Class spaces|Command Center/i.test(
       await page
         .locator("body")
         .innerText({ timeout: 1_000 })
@@ -131,17 +131,25 @@ export async function ensureDemoSignedIn(page: Page) {
     return;
   }
 
+  const demo = page
+    .getByRole("button", { name: /^Open demo$/i })
+    .first();
+
   // Fast-path recovery for sessions that are already authenticated but landed
   // on a transient shell route that does not satisfy older dashboard checks.
-  await page.goto('/os/home').catch(() => undefined);
-  await ensureFlutterSemantics(page);
-  if (isSignedInRoute() || (await isSignedInSurfaceVisible())) {
-    return;
+  const demoAlreadyVisible = await demo
+    .isVisible({ timeout: 1_000 })
+    .catch(() => false);
+  if (!demoAlreadyVisible) {
+    await page.goto('/os/home').catch(() => undefined);
+    await ensureFlutterSemantics(page);
+    if (isSignedInRoute() || (await isSignedInSurfaceVisible())) {
+      return;
+    }
   }
 
-  const demo = page.getByRole("button", { name: /^Try Demo Account$/i }).first();
   const enteringWorkspace = page
-    .getByRole("button", { name: /^Entering workspace\.\.\.$/i })
+    .getByRole("button", { name: /^Opening\.\.\.$/i })
     .first();
   const loadingShell = page.getByText(/Loading workspace shell/i).first();
   let loadingShellVisibleSince: number | null = null;
@@ -387,7 +395,7 @@ export async function openFirstClassWorkspace(page: Page) {
   }
 
   const classEntries = page.getByRole("group", {
-    name: /Open class workspace|Grade .*students/i,
+    name: /Open class workspace|Grade .*students|Grade\s+\d+[A-Z]?\b/i,
   });
   const hasClassEntry = await classEntries
     .first()

--- a/e2e/seating_room_setup.spec.ts
+++ b/e2e/seating_room_setup.spec.ts
@@ -8,7 +8,7 @@ import {
   openFirstClassWorkspace,
 } from "./helpers";
 
-test("Seating: room setup save flow works from the toolbar", async ({
+test("@regression Seating: room setup save flow works from the toolbar", async ({
   page,
 }) => {
   test.setTimeout(180_000);

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -5,29 +5,30 @@ import {
   expectDashboardShell,
 } from './helpers';
 
-test('login screen loads', async ({ page }) => {
+test('@smoke login screen loads', async ({ page }) => {
   await page.goto('/');
 
   await ensureFlutterSemantics(page);
 
-  await expect(page.getByText('Enter GradeFlow')).toBeVisible();
+  await expect(page.getByText('InstructOS')).toBeVisible();
+  await expect(page.getByText('Sign in')).toBeVisible();
 
   await expect(page.getByLabel('Email')).toBeVisible();
   await expect(page.getByLabel('Password')).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Enter' })).toBeVisible();
   await expect(
     page.getByRole('button', { name: 'Continue with Google' }),
   ).toBeVisible();
   await expect(
-    page.getByRole('button', { name: 'Try Demo Account' }),
+    page.getByRole('button', { name: 'Open demo' }),
   ).toBeVisible();
 });
 
-test('demo login opens authenticated workspace', async ({ page }) => {
-  test.setTimeout(120_000);
+test('@smoke demo login opens authenticated workspace', async ({ page }) => {
+  test.setTimeout(240_000);
   await page.goto('/');
 
   await ensureDemoSignedIn(page);
-  await expect(page).toHaveURL(/\/(?:dashboard|os\/home)(?:\?|$)/);
+  await expect(page).toHaveURL(/(?:\/|\/#\/)(?:dashboard|os\/home)(?:[?#]|$)/);
   await expectDashboardShell(page);
 });

--- a/e2e/student_reporting_trust.spec.ts
+++ b/e2e/student_reporting_trust.spec.ts
@@ -23,7 +23,7 @@ async function selectDropdownOption(
   await activateControl(page.getByRole('menuitem', { name: nextValue }).first());
 }
 
-test('Exam input: valid save persists into results and invalid score is rejected', async ({
+test('@regression Exam input: valid save persists into results and invalid score is rejected', async ({
   page,
 }) => {
   test.setTimeout(240_000);
@@ -66,25 +66,25 @@ test('Exam input: valid save persists into results and invalid score is rejected
   );
 });
 
-test('Final results: weighted results surface loads with roster context', async ({
+test('@core Final results: weighted results surface loads with roster context', async ({
   page,
 }) => {
   test.setTimeout(180_000);
 
   await gotoSignedInPath(page, '/class/demo-class-1/results');
 
-  await expect(
-    page.getByRole('group', {
-      name: /Final Results.*Grade 10A.*Mathematics \/ 2024-2025 \/ Fall \/ 5 students/i,
-    }),
-  ).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByText('Final Results', { exact: true }).first()).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(page.locator('body')).toContainText('Grade 10A');
+  await expect(page.locator('body')).toContainText('Mathematics / 2024-2025 / Fall / 5 students');
   await expect(page.locator('body')).toContainText('Process 40%');
   await expect(page.locator('body')).toContainText('Exam 60%');
   await expect(page.locator('body')).toContainText('Final grade');
   await expect(page.locator('body')).toContainText('demo-class-1-student-1');
 });
 
-test('Student flows: roster search narrows results and detail view stays coherent', async ({
+test('@core Student flows: roster search narrows results and detail view stays coherent', async ({
   page,
 }) => {
   test.setTimeout(180_000);
@@ -111,7 +111,9 @@ test('Student flows: roster search narrows results and detail view stays coheren
   await page.goto('/class/demo-class-1/student/demo-class-1-student-2');
   await ensureFlutterSemantics(page);
 
-  await expect(page).toHaveURL(/\/class\/demo-class-1\/student\/demo-class-1-student-2(?:\?|$)/);
+  await expect(page).toHaveURL(
+    /(?:\/|\/#\/)(?:os\/)?class\/demo-class-1\/student\/demo-class-1-student-2(?:[?#]|$)/,
+  );
   await expect(page.getByText('Grade breakdown', { exact: true }).first()).toBeVisible({
     timeout: 60_000,
   });
@@ -121,7 +123,7 @@ test('Student flows: roster search narrows results and detail view stays coheren
   await expect(page.locator('body')).toContainText('Final grade');
 });
 
-test('Export: per-student scope previews the selected student report', async ({
+test('@regression Export: per-student scope previews the selected student report', async ({
   page,
 }) => {
   test.setTimeout(180_000);
@@ -143,7 +145,7 @@ test('Export: per-student scope previews the selected student report', async ({
   await expect(page.locator('body')).toContainText('demo-class-1-student-1');
 });
 
-test('Export: all-classes scope keeps trust messaging visible and previews combined CSV', async ({
+test('@regression Export: all-classes scope keeps trust messaging visible and previews combined CSV', async ({
   page,
 }) => {
   test.setTimeout(180_000);

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>GradeFlow</string>
+	<string>InstructOS</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/lib/components/gradeflow_launch_experience.dart
+++ b/lib/components/gradeflow_launch_experience.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:gradeflow/components/animated_page_background.dart';
-import 'package:gradeflow/config/gradeflow_product_config.dart';
+import 'package:gradeflow/config/instructos_branding.dart';
 import 'package:gradeflow/services/auth_service.dart';
+import 'package:gradeflow/widgets/branding/instructos_interactive_auth_background.dart';
 
 class GradeFlowLaunchGate extends StatefulWidget {
   final Widget child;
@@ -70,7 +70,7 @@ class _GradeFlowLaunchGateState extends State<GradeFlowLaunchGate> {
               )
             : KeyedSubtree(
                 key: const ValueKey<String>('launch-experience'),
-                child: _GradeFlowLaunchExperience(auth: auth),
+                child: const _GradeFlowLaunchExperience(),
               ),
       ),
     );
@@ -78,38 +78,15 @@ class _GradeFlowLaunchGateState extends State<GradeFlowLaunchGate> {
 }
 
 class _GradeFlowLaunchExperience extends StatelessWidget {
-  final AuthService auth;
-
-  const _GradeFlowLaunchExperience({
-    required this.auth,
-  });
-
-  String _statusLine() {
-    if (!auth.isInitialized && auth.isLoading) {
-      return 'Restoring your secure classroom workspace...';
-    }
-    if (!auth.isInitialized) {
-      return 'Preparing your classroom workspace...';
-    }
-    if (auth.isAuthenticated) {
-      return 'Workspace ready. Opening ${GradeFlowProductConfig.appName}...';
-    }
-    return 'Secure access is ready.';
-  }
-
-  double _progressValue() {
-    if (!auth.isInitialized) return auth.isLoading ? 0.42 : 0.28;
-    return auth.isAuthenticated ? 1.0 : 0.86;
-  }
+  const _GradeFlowLaunchExperience();
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final progress = _progressValue();
 
     return Scaffold(
       backgroundColor: const Color(0xFF050912),
-      body: AnimatedPageBackground(
+      body: InstructOSInteractiveAuthBackground(
         child: LayoutBuilder(
           builder: (context, constraints) {
             final compact = constraints.maxWidth < 640;
@@ -126,40 +103,32 @@ class _GradeFlowLaunchExperience extends StatelessWidget {
                 ),
                 child: Center(
                   child: ConstrainedBox(
-                    constraints: const BoxConstraints(maxWidth: 620),
+                    constraints: const BoxConstraints(maxWidth: 430),
                     child: Column(
                       mainAxisSize: MainAxisSize.min,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        _LaunchTextLockup(compact: compact),
-                        const SizedBox(height: 16),
-                        ConstrainedBox(
-                          constraints: const BoxConstraints(maxWidth: 460),
-                          child: Text(
-                            GradeFlowProductConfig.marketingTagline,
-                            textAlign: TextAlign.center,
-                            style: theme.textTheme.titleMedium?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant,
-                              height: 1.4,
-                              fontWeight: FontWeight.w500,
-                            ),
+                        Text(
+                          InstructOSBranding.productName,
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.headlineSmall?.copyWith(
+                            color: Colors.white,
+                            fontWeight: FontWeight.w900,
+                            letterSpacing: 0,
                           ),
                         ),
-                        const SizedBox(height: 26),
-                        _LaunchProgressLine(value: progress),
-                        const SizedBox(height: 14),
-                        ConstrainedBox(
-                          constraints: const BoxConstraints(maxWidth: 460),
-                          child: Text(
-                            _statusLine(),
-                            textAlign: TextAlign.center,
-                            style: theme.textTheme.bodyMedium?.copyWith(
-                              color: theme.colorScheme.onSurfaceVariant
-                                  .withValues(alpha: 0.92),
-                              height: 1.45,
-                            ),
+                        const SizedBox(height: 6),
+                        Text(
+                          'Teaching, organised.',
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color:
+                                const Color(0xFFD7DDF1).withValues(alpha: 0.72),
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
+                        const SizedBox(height: 24),
+                        const _LaunchPulseDot(),
                       ],
                     ),
                   ),
@@ -173,118 +142,46 @@ class _GradeFlowLaunchExperience extends StatelessWidget {
   }
 }
 
-class _LaunchTextLockup extends StatelessWidget {
-  const _LaunchTextLockup({required this.compact});
+class _LaunchPulseDot extends StatefulWidget {
+  const _LaunchPulseDot();
 
-  final bool compact;
+  @override
+  State<_LaunchPulseDot> createState() => _LaunchPulseDotState();
+}
+
+class _LaunchPulseDotState extends State<_LaunchPulseDot>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1500),
+  )..repeat(reverse: true);
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final symbolSize = compact ? 34.0 : 42.0;
-    final nameSize = compact ? 34.0 : 44.0;
-    final symbolStyle = theme.textTheme.headlineMedium?.copyWith(
-          fontSize: symbolSize,
-          fontWeight: FontWeight.w700,
-          height: 1.0,
-          letterSpacing: -0.3,
-          color: theme.colorScheme.onSurface,
-        ) ??
-        TextStyle(
-          fontSize: symbolSize,
-          fontWeight: FontWeight.w700,
-          height: 1.0,
-          letterSpacing: -0.3,
-          color: theme.colorScheme.onSurface,
-        );
-
-    final nameStyle = theme.textTheme.displaySmall?.copyWith(
-          fontSize: nameSize,
-          fontWeight: FontWeight.w700,
-          height: 1.0,
-          letterSpacing: -0.4,
-          color: theme.colorScheme.onSurface,
-        ) ??
-        TextStyle(
-          fontSize: nameSize,
-          fontWeight: FontWeight.w700,
-          height: 1.0,
-          letterSpacing: -0.4,
-          color: theme.colorScheme.onSurface,
-        );
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text('I', style: symbolStyle),
-            Text(
-              '/',
-              style: symbolStyle.copyWith(
-                color: const Color(0xFF2A6BFF),
-              ),
-            ),
-            Text(
-              'OS',
-              style: symbolStyle.copyWith(
-                color: const Color(0xFF22D3EE),
-              ),
+    return FadeTransition(
+      opacity: Tween<double>(begin: 0.36, end: 0.88).animate(
+        CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+      ),
+      child: Container(
+        width: 7,
+        height: 7,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: const Color(0xFFB8C3FF).withValues(alpha: 0.90),
+          boxShadow: [
+            BoxShadow(
+              color: const Color(0xFF8B5CF6).withValues(alpha: 0.34),
+              blurRadius: 16,
+              spreadRadius: 3,
             ),
           ],
         ),
-        const SizedBox(height: 6),
-        Text(
-          GradeFlowProductConfig.appName,
-          style: nameStyle,
-          textAlign: TextAlign.center,
-        ),
-      ],
-    );
-  }
-}
-
-class _LaunchProgressLine extends StatelessWidget {
-  const _LaunchProgressLine({required this.value});
-
-  final double value;
-
-  @override
-  Widget build(BuildContext context) {
-    final trackColor = Colors.white.withValues(alpha: 0.12);
-    final clamped = value.clamp(0.0, 1.0);
-
-    return ConstrainedBox(
-      constraints: const BoxConstraints(maxWidth: 280),
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          final width = constraints.maxWidth;
-          return Stack(
-            children: [
-              Container(
-                height: 3,
-                width: width,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(999),
-                  color: trackColor,
-                ),
-              ),
-              AnimatedContainer(
-                duration: const Duration(milliseconds: 300),
-                curve: Curves.easeOutCubic,
-                height: 3,
-                width: width * clamped,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(999),
-                  gradient: const LinearGradient(
-                    colors: [Color(0xFF5C88FF), Color(0xFF22D3EE)],
-                  ),
-                ),
-              ),
-            ],
-          );
-        },
       ),
     );
   }

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -361,6 +361,27 @@ class _HomeSurfaceState extends State<HomeSurface> {
   }
 }
 
+Widget _homeFolderTransition(Widget child, Animation<double> animation) {
+  final curved = CurvedAnimation(
+    parent: animation,
+    curve: Curves.easeOutCubic,
+    reverseCurve: Curves.easeInOut,
+  );
+  return FadeTransition(
+    opacity: curved,
+    child: SlideTransition(
+      position: Tween<Offset>(
+        begin: const Offset(0, -0.035),
+        end: Offset.zero,
+      ).animate(curved),
+      child: ScaleTransition(
+        scale: Tween<double>(begin: 0.985, end: 1).animate(curved),
+        child: child,
+      ),
+    ),
+  );
+}
+
 class _HomeDesktopLayout extends StatefulWidget {
   const _HomeDesktopLayout({
     required this.teacherName,
@@ -417,32 +438,31 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
       children: [
         SizedBox(
           width: 248,
-          child: Align(
-            alignment: Alignment.topLeft,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                _HomeSchoolIdentity(
-                  teacherName: widget.teacherName,
-                  schoolName: widget.schoolName,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              _HomeSchoolIdentity(
+                teacherName: widget.teacherName,
+                schoolName: widget.schoolName,
+                unread: widget.unread,
+                themeMode: widget.themeMode,
+                onAssistantTap: widget.onAssistantTap,
+                onShadeTap: widget.onShadeTap,
+                onThemeTap: widget.onThemeTap,
+                onWallpaperTap: widget.onWallpaperTap,
+              ),
+              const SizedBox(height: 14),
+              SizedBox(
+                height: 202,
+                child: _HomeShortcutShelf(
                   unread: widget.unread,
-                  themeMode: widget.themeMode,
-                  onAssistantTap: widget.onAssistantTap,
-                  onShadeTap: widget.onShadeTap,
-                  onThemeTap: widget.onThemeTap,
-                  onWallpaperTap: widget.onWallpaperTap,
+                  onLauncherTap: widget.onLauncherTap,
+                  compact: true,
                 ),
-                const SizedBox(height: 14),
-                SizedBox(
-                  height: 202,
-                  child: _HomeShortcutShelf(
-                    unread: widget.unread,
-                    onLauncherTap: widget.onLauncherTap,
-                    compact: true,
-                  ),
-                ),
-              ],
-            ),
+              ),
+              const Spacer(),
+              _HomeQuickClassesStrip(classes: widget.classes),
+            ],
           ),
         ),
         const SizedBox(width: 16),
@@ -474,14 +494,14 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                     groupId: _folderTapRegionGroup,
                     onTapOutside: (_) => _closeSelectedFolder(),
                     child: _HomeWorkspaceFolderStrip(
-                    selected: _selectedFolder,
-                    classCount: widget.classes.length,
-                    reminderCount: widget.reminders.length,
-                    unread: widget.unread,
-                    onSelected: (folder) => setState(() {
-                      _selectedFolder =
-                          _selectedFolder == folder ? null : folder;
-                    }),
+                      selected: _selectedFolder,
+                      classCount: widget.classes.length,
+                      reminderCount: widget.reminders.length,
+                      unread: widget.unread,
+                      onSelected: (folder) => setState(() {
+                        _selectedFolder =
+                            _selectedFolder == folder ? null : folder;
+                      }),
                     ),
                   ),
                   const SizedBox(height: 14),
@@ -492,7 +512,8 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                       child: AnimatedSwitcher(
                         duration: const Duration(milliseconds: 240),
                         switchInCurve: Curves.easeOutCubic,
-                        switchOutCurve: Curves.easeInCubic,
+                        switchOutCurve: Curves.easeInOut,
+                        transitionBuilder: _homeFolderTransition,
                         child: _selectedFolder == null
                             ? const _HomeCalmWorkspaceFloor(
                                 key: ValueKey('workspace-closed'),
@@ -501,14 +522,14 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                                 groupId: _folderTapRegionGroup,
                                 onTapOutside: (_) => _closeSelectedFolder(),
                                 child: _HomeWorkspaceFolderPanel(
-                                key: ValueKey(_selectedFolder),
-                                folder: _selectedFolder!,
-                                primaryClass: widget.primaryClass,
-                                classes: widget.classes,
-                                reminders: widget.reminders,
-                                unread: widget.unread,
-                                totalStudents: widget.totalStudents,
-                                now: widget.now,
+                                  key: ValueKey(_selectedFolder),
+                                  folder: _selectedFolder!,
+                                  primaryClass: widget.primaryClass,
+                                  classes: widget.classes,
+                                  reminders: widget.reminders,
+                                  unread: widget.unread,
+                                  totalStudents: widget.totalStudents,
+                                  now: widget.now,
                                 ),
                               ),
                       ),
@@ -625,6 +646,155 @@ class _HomeUtilityRail extends StatelessWidget {
   }
 }
 
+class _HomeQuickClassesStrip extends StatelessWidget {
+  const _HomeQuickClassesStrip({required this.classes});
+
+  final List<Class> classes;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    final visible = classes.take(4).toList();
+
+    return _GlassPanel(
+      tone: _HomePanelTone.rail,
+      radius: 24,
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.grid_view_rounded,
+                size: 15,
+                color: OSColors.textMuted(dark),
+              ),
+              const SizedBox(width: 7),
+              Expanded(
+                child: Text(
+                  'Quick Classes',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w800,
+                    color: OSColors.textSecondary(dark),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          if (visible.isEmpty)
+            _HomeQuickClassTile(
+              label: 'Open classes',
+              detail: 'Set up the first workspace',
+              accent: OSColors.green,
+              onTap: () => context.go(AppRoutes.classes),
+            )
+          else
+            for (int index = 0; index < visible.length; index++) ...[
+              _HomeQuickClassTile(
+                label: visible[index].className,
+                detail: visible[index].subject,
+                accent: _classAccent(index),
+                onTap: () => context.go(
+                  AppRoutes.osClassWorkspace(visible[index].classId),
+                ),
+              ),
+              if (index != visible.length - 1) const SizedBox(height: 8),
+            ],
+        ],
+      ),
+    );
+  }
+}
+
+class _HomeQuickClassTile extends StatelessWidget {
+  const _HomeQuickClassTile({
+    required this.label,
+    required this.detail,
+    required this.accent,
+    required this.onTap,
+  });
+
+  final String label;
+  final String detail;
+  final Color accent;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+
+    return OSTouchFeedback(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      minSize: const Size(180, 48),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(10, 9, 10, 9),
+        decoration: BoxDecoration(
+          color: dark
+              ? Colors.white.withValues(alpha: 0.036)
+              : Colors.white.withValues(alpha: 0.62),
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: accent.withValues(alpha: dark ? 0.18 : 0.16),
+          ),
+        ),
+        child: Row(
+          children: [
+            Container(
+              width: 8,
+              height: 28,
+              decoration: BoxDecoration(
+                color: accent.withValues(alpha: dark ? 0.70 : 0.82),
+                borderRadius: OSRadius.pillBr,
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12,
+                      fontWeight: FontWeight.w800,
+                      color: OSColors.text(dark),
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    detail,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 10.5,
+                      color: OSColors.textMuted(dark),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Icon(
+              Icons.chevron_right_rounded,
+              size: 17,
+              color: OSColors.textMuted(dark),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 enum _HomeWorkspaceFolder {
   today(label: 'Today', icon: Icons.today_rounded, accent: OSColors.blue),
   classes(label: 'Classes', icon: Icons.class_rounded, accent: OSColors.green),
@@ -701,13 +871,13 @@ class _HomeWorkspaceFolderStrip extends StatelessWidget {
 
   String _folderDetail(_HomeWorkspaceFolder folder) {
     return switch (folder) {
-      _HomeWorkspaceFolder.today => 'Open space',
+      _HomeWorkspaceFolder.today => 'Next up',
       _HomeWorkspaceFolder.classes =>
         classCount == 0 ? 'No classes' : '$classCount active',
       _HomeWorkspaceFolder.tasks =>
         reminderCount == 0 ? 'Clear' : '$reminderCount queued',
       _HomeWorkspaceFolder.messages => unread == 0 ? 'Quiet' : '$unread unread',
-      _HomeWorkspaceFolder.insights => 'Overview',
+      _HomeWorkspaceFolder.insights => 'Signals',
     };
   }
 }
@@ -894,38 +1064,22 @@ class _HomeCalmWorkspaceFloor extends StatelessWidget {
             ),
           ),
           Positioned(
-            top: 34,
+            left: 44,
+            right: 44,
+            top: 42,
+            bottom: 52,
             child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
               decoration: BoxDecoration(
-                color: dark
-                    ? Colors.white.withValues(alpha: 0.040)
-                    : Colors.white.withValues(alpha: 0.56),
-                borderRadius: OSRadius.pillBr,
-                border: Border.all(
-                  color: dark
-                      ? Colors.white.withValues(alpha: 0.065)
-                      : Colors.white.withValues(alpha: 0.70),
+                borderRadius: BorderRadius.circular(28),
+                gradient: RadialGradient(
+                  center: const Alignment(-0.35, -0.45),
+                  radius: 1.0,
+                  colors: [
+                    OSColors.blue.withValues(alpha: dark ? 0.075 : 0.12),
+                    OSColors.cyan.withValues(alpha: dark ? 0.025 : 0.06),
+                    Colors.transparent,
+                  ],
                 ),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Icon(
-                    Icons.keyboard_arrow_down_rounded,
-                    size: 16,
-                    color: OSColors.textMuted(dark),
-                  ),
-                  const SizedBox(width: 6),
-                  Text(
-                    'Choose a folder when you need more',
-                    style: TextStyle(
-                      fontSize: 11,
-                      fontWeight: FontWeight.w700,
-                      color: OSColors.textMuted(dark),
-                    ),
-                  ),
-                ],
               ),
             ),
           ),
@@ -972,7 +1126,7 @@ class _HomeWorkspaceFolderPanel extends StatelessWidget {
     return switch (folder) {
       _HomeWorkspaceFolder.today => _TodayFolderContent(
           primaryClass: primaryClass,
-          primaryReminder: reminders.isEmpty ? null : reminders.first,
+          reminders: reminders,
           unread: unread,
           now: now,
         ),
@@ -995,31 +1149,34 @@ class _HomeWorkspaceFolderPanel extends StatelessWidget {
 class _TodayFolderContent extends StatelessWidget {
   const _TodayFolderContent({
     required this.primaryClass,
-    required this.primaryReminder,
+    required this.reminders,
     required this.unread,
     required this.now,
   });
 
   final Class? primaryClass;
-  final TeacherWorkspaceReminderSnapshot? primaryReminder;
+  final List<TeacherWorkspaceReminderSnapshot> reminders;
   final int unread;
   final DateTime now;
 
   @override
   Widget build(BuildContext context) {
+    final visibleReminders = reminders.take(2).toList();
     return _FolderPanelScaffold(
       eyebrow: 'Today',
       title: _formatLongDate(now),
-      subtitle: unread == 0
-          ? 'The workspace is quiet. Pull down what you need when you need it.'
-          : '$unread unread message${unread == 1 ? '' : 's'} waiting quietly.',
-      actionLabel: primaryClass == null ? 'Open Classes' : 'Open next class',
+      subtitle: primaryClass == null
+          ? 'Start from the class list or check the planning lane.'
+          : 'Your next workspace and near tasks are ready.',
+      actionLabel: primaryClass == null ? 'View Schedule' : 'Open Class',
       actionIcon: Icons.arrow_forward_rounded,
       onAction: () => context.go(
         primaryClass == null
-            ? AppRoutes.classes
+            ? AppRoutes.osPlanner
             : AppRoutes.osClassWorkspace(primaryClass!.classId),
       ),
+      secondaryLabel: 'View Schedule',
+      onSecondary: () => context.go(AppRoutes.osPlanner),
       child: Column(
         children: [
           _FolderInfoRow(
@@ -1029,25 +1186,32 @@ class _TodayFolderContent extends StatelessWidget {
             value: primaryClass == null
                 ? 'No class pinned yet'
                 : '${primaryClass!.className} / ${primaryClass!.subject}',
+            onTap: () => context.go(
+              primaryClass == null
+                  ? AppRoutes.classes
+                  : AppRoutes.osClassWorkspace(primaryClass!.classId),
+            ),
           ),
-          const SizedBox(height: 10),
-          _FolderInfoRow(
-            icon: Icons.event_note_outlined,
-            accent: OSColors.amber,
-            label: 'Focus item',
-            value: primaryReminder == null
-                ? 'No pending reminders'
-                : _trimLine(primaryReminder!.text, 82),
-          ),
-          const SizedBox(height: 10),
-          _FolderInfoRow(
-            icon: Icons.check_circle_outline_rounded,
-            accent: OSColors.blue,
-            label: 'Day status',
-            value: primaryReminder == null && unread == 0
-                ? 'Ready and uncluttered'
-                : 'Signals are staged without crowding the desktop',
-          ),
+          if (visibleReminders.isEmpty) ...[
+            const SizedBox(height: 10),
+            _FolderInfoRow(
+              icon: Icons.calendar_month_rounded,
+              accent: OSColors.blue,
+              label: 'Schedule',
+              value: 'Open the planning lane',
+              onTap: () => context.go(AppRoutes.osPlanner),
+            ),
+          ] else
+            for (int index = 0; index < visibleReminders.length; index++) ...[
+              const SizedBox(height: 10),
+              _FolderInfoRow(
+                icon: Icons.event_note_outlined,
+                accent: OSColors.amber,
+                label: _relativeReminderLabel(visibleReminders[index], now),
+                value: _trimLine(visibleReminders[index].text, 82),
+                onTap: () => context.go(AppRoutes.osPlanner),
+              ),
+            ],
         ],
       ),
     );
@@ -1089,6 +1253,9 @@ class _ClassesFolderContent extends StatelessWidget {
                 accent: OSColors.green,
                 label: visible[index].className,
                 value: '${visible[index].subject} / ${visible[index].term}',
+                onTap: () => context.go(
+                  AppRoutes.osClassWorkspace(visible[index].classId),
+                ),
               ),
               if (index != visible.length - 1) const SizedBox(height: 10),
             ],
@@ -1130,6 +1297,7 @@ class _TasksFolderContent extends StatelessWidget {
                 accent: OSColors.amber,
                 label: _relativeReminderLabel(visible[index], now),
                 value: _trimLine(visible[index].text, 90),
+                onTap: () => context.go(AppRoutes.osPlanner),
               ),
               if (index != visible.length - 1) const SizedBox(height: 10),
             ],
@@ -1158,19 +1326,31 @@ class _MessagesFolderContent extends StatelessWidget {
       child: Column(
         children: [
           _FolderInfoRow(
-            icon: Icons.mark_email_read_outlined,
+            icon: unread == 0
+                ? Icons.mark_email_read_outlined
+                : Icons.mark_chat_unread_outlined,
             accent: OSColors.cyan,
-            label: 'Inbox',
+            label: unread == 0 ? 'Staff room' : 'Unread',
             value: unread == 0
-                ? 'No unread conversations'
-                : 'Unread conversations are waiting',
+                ? 'Open recent channels'
+                : '$unread conversation${unread == 1 ? '' : 's'} need review',
+            onTap: () => context.go(AppRoutes.communication),
           ),
           const SizedBox(height: 10),
           _FolderInfoRow(
-            icon: Icons.shield_moon_outlined,
+            icon: Icons.groups_2_outlined,
             accent: OSColors.blue,
-            label: 'Focus mode',
-            value: 'Messages stay nearby without taking over the desktop',
+            label: 'Class channels',
+            value: 'Families, students, and staff threads',
+            onTap: () => context.go(AppRoutes.communication),
+          ),
+          const SizedBox(height: 10),
+          _FolderInfoRow(
+            icon: Icons.campaign_outlined,
+            accent: OSColors.indigo,
+            label: 'Announcements',
+            value: 'Review school-wide updates',
+            onTap: () => context.go(AppRoutes.communication),
           ),
         ],
       ),
@@ -1205,19 +1385,29 @@ class _InsightsFolderContent extends StatelessWidget {
         runSpacing: 10,
         children: [
           _FolderMetric(
-              label: 'Classes', value: '$classCount', accent: OSColors.green),
+            label: 'Classes',
+            value: '$classCount',
+            accent: OSColors.green,
+            onTap: () => context.go(AppRoutes.classes),
+          ),
           _FolderMetric(
-              label: 'Students',
-              value: '$totalStudents',
-              accent: OSColors.cyan),
+            label: 'Students',
+            value: '$totalStudents',
+            accent: OSColors.cyan,
+            onTap: () => context.go(AppRoutes.classes),
+          ),
           _FolderMetric(
-              label: 'Messages',
-              value: unread == 0 ? 'Quiet' : '$unread',
-              accent: OSColors.blue),
+            label: 'Messages',
+            value: unread == 0 ? 'Quiet' : '$unread',
+            accent: OSColors.blue,
+            onTap: () => context.go(AppRoutes.communication),
+          ),
           _FolderMetric(
-              label: 'Tasks',
-              value: reminderCount == 0 ? 'Clear' : '$reminderCount',
-              accent: OSColors.amber),
+            label: 'Tasks',
+            value: reminderCount == 0 ? 'Clear' : '$reminderCount',
+            accent: OSColors.amber,
+            onTap: () => context.go(AppRoutes.osPlanner),
+          ),
         ],
       ),
     );
@@ -1344,17 +1534,19 @@ class _FolderInfoRow extends StatelessWidget {
     required this.accent,
     required this.label,
     required this.value,
+    this.onTap,
   });
 
   final IconData icon;
   final Color accent;
   final String label;
   final String value;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
-    return Container(
+    final row = Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
       decoration: BoxDecoration(
         color: dark
@@ -1396,8 +1588,25 @@ class _FolderInfoRow extends StatelessWidget {
               ),
             ),
           ),
+          if (onTap != null) ...[
+            const SizedBox(width: 8),
+            Icon(
+              Icons.chevron_right_rounded,
+              size: 18,
+              color: OSColors.textMuted(dark),
+            ),
+          ],
         ],
       ),
+    );
+
+    if (onTap == null) return row;
+
+    return OSTouchFeedback(
+      onTap: onTap!,
+      borderRadius: BorderRadius.circular(18),
+      minSize: const Size(220, 46),
+      child: row,
     );
   }
 }
@@ -1407,16 +1616,18 @@ class _FolderMetric extends StatelessWidget {
     required this.label,
     required this.value,
     required this.accent,
+    this.onTap,
   });
 
   final String label;
   final String value;
   final Color accent;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
-    return Container(
+    final metric = Container(
       width: 132,
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
@@ -1448,6 +1659,15 @@ class _FolderMetric extends StatelessWidget {
           ),
         ],
       ),
+    );
+
+    if (onTap == null) return metric;
+
+    return OSTouchFeedback(
+      onTap: onTap!,
+      borderRadius: BorderRadius.circular(18),
+      minSize: const Size(132, 72),
+      child: metric,
     );
   }
 }
@@ -1558,19 +1778,20 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
           groupId: _folderTapRegionGroup,
           onTapOutside: (_) => _closeSelectedFolder(),
           child: _HomeWorkspaceFolderStrip(
-          selected: _selectedFolder,
-          classCount: widget.classes.length,
-          reminderCount: widget.reminders.length,
-          unread: widget.unread,
-          onSelected: (folder) => setState(() {
-            _selectedFolder = _selectedFolder == folder ? null : folder;
-          }),
+            selected: _selectedFolder,
+            classCount: widget.classes.length,
+            reminderCount: widget.reminders.length,
+            unread: widget.unread,
+            onSelected: (folder) => setState(() {
+              _selectedFolder = _selectedFolder == folder ? null : folder;
+            }),
           ),
         ),
         AnimatedSwitcher(
           duration: const Duration(milliseconds: 240),
           switchInCurve: Curves.easeOutCubic,
-          switchOutCurve: Curves.easeInCubic,
+          switchOutCurve: Curves.easeInOut,
+          transitionBuilder: _homeFolderTransition,
           child: _selectedFolder == null
               ? const Padding(
                   key: ValueKey('workspace-closed'),
@@ -1584,13 +1805,13 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
                     key: ValueKey(_selectedFolder),
                     padding: const EdgeInsets.only(top: 14),
                     child: _HomeWorkspaceFolderPanel(
-                    folder: _selectedFolder!,
-                    primaryClass: widget.primaryClass,
-                    classes: widget.classes,
-                    reminders: widget.reminders,
-                    unread: widget.unread,
-                    totalStudents: widget.totalStudents,
-                    now: widget.now,
+                      folder: _selectedFolder!,
+                      primaryClass: widget.primaryClass,
+                      classes: widget.classes,
+                      reminders: widget.reminders,
+                      unread: widget.unread,
+                      totalStudents: widget.totalStudents,
+                      now: widget.now,
                     ),
                   ),
                 ),
@@ -1606,6 +1827,10 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
           reminderCount: widget.reminders.length,
           children: [
             const _HomeWeatherPanel(embedded: true),
+            _HomeAudioPanel(
+              embedded: true,
+              onTap: () => context.go(AppRoutes.dashboard),
+            ),
             _HomeAgendaPanel(
               reminders: widget.reminders,
               scrollable: false,
@@ -3092,6 +3317,10 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
         final hasError = snapshot.hasError && data == null;
         final forecast =
             data?.forecast.take(2).toList() ?? const <DashboardForecastDay>[];
+        final mood = _weatherMood(data?.weatherCode, DateTime.now(), dark);
+        final textOnWeather = _weatherTextColor(mood, dark);
+        final mutedOnWeather = _weatherMutedTextColor(mood, dark);
+        final iconOnWeather = _weatherAccentColor(mood, dark);
 
         final content = Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -3105,7 +3334,7 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
                   data == null
                       ? Icons.cloud_queue_rounded
                       : _weatherIcon(data.weatherCode),
-                  color: OSColors.blue,
+                  color: iconOnWeather,
                   size: 20,
                 ),
               ],
@@ -3121,7 +3350,7 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
                 fontSize: 18,
                 height: 1.1,
                 fontWeight: FontWeight.w800,
-                color: OSColors.text(dark),
+                color: textOnWeather,
               ),
             ),
             const SizedBox(height: 5),
@@ -3136,7 +3365,7 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
               style: TextStyle(
                 fontSize: 12,
                 height: 1.4,
-                color: OSColors.textSecondary(dark),
+                color: mutedOnWeather,
               ),
             ),
             if (forecast.isNotEmpty) ...[
@@ -3154,16 +3383,140 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
             ],
           ],
         );
-        return widget.embedded
-            ? _RailSection(child: content)
-            : _GlassPanel(
-                tone: _HomePanelTone.whisper,
-                radius: 28,
-                padding: const EdgeInsets.all(16),
-                child: content,
-              );
+        return _WeatherWidgetFrame(
+          mood: mood,
+          embedded: widget.embedded,
+          child: content,
+        );
       },
     );
+  }
+}
+
+enum _WeatherMood { rain, cloudy, sunny, night }
+
+class _WeatherWidgetFrame extends StatelessWidget {
+  const _WeatherWidgetFrame({
+    required this.mood,
+    required this.embedded,
+    required this.child,
+  });
+
+  final _WeatherMood mood;
+  final bool embedded;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    final radius = BorderRadius.circular(embedded ? 24 : 28);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        borderRadius: radius,
+        gradient: LinearGradient(
+          colors: _weatherGradient(mood, dark),
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        border: Border.all(
+          color: Colors.white.withValues(alpha: dark ? 0.10 : 0.48),
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: _weatherAccentColor(mood, dark).withValues(
+              alpha: dark ? 0.12 : 0.10,
+            ),
+            blurRadius: 22,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: radius,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: CustomPaint(
+                painter: _WeatherAtmospherePainter(
+                  mood: mood,
+                  dark: dark,
+                ),
+              ),
+            ),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _WeatherAtmospherePainter extends CustomPainter {
+  const _WeatherAtmospherePainter({
+    required this.mood,
+    required this.dark,
+  });
+
+  final _WeatherMood mood;
+  final bool dark;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..style = PaintingStyle.stroke;
+    if (mood == _WeatherMood.rain) {
+      paint
+        ..color = Colors.white.withValues(alpha: dark ? 0.12 : 0.22)
+        ..strokeWidth = 1.1
+        ..strokeCap = StrokeCap.round;
+      for (double x = 8; x < size.width; x += 22) {
+        canvas.drawLine(
+          Offset(x, 8),
+          Offset(x - 12, size.height - 10),
+          paint,
+        );
+      }
+      return;
+    }
+
+    if (mood == _WeatherMood.cloudy) {
+      final fill = Paint()
+        ..style = PaintingStyle.fill
+        ..color = Colors.white.withValues(alpha: dark ? 0.065 : 0.24);
+      canvas.drawOval(
+        Rect.fromLTWH(size.width * .48, 8, size.width * .62, 64),
+        fill,
+      );
+      canvas.drawOval(
+        Rect.fromLTWH(size.width * .36, 32, size.width * .58, 74),
+        fill,
+      );
+      return;
+    }
+
+    final glowPaint = Paint()
+      ..shader = RadialGradient(
+        colors: [
+          Colors.white.withValues(alpha: dark ? 0.14 : 0.30),
+          Colors.transparent,
+        ],
+      ).createShader(
+        Rect.fromCircle(
+          center: Offset(size.width * .84, size.height * .10),
+          radius: 90,
+        ),
+      );
+    canvas.drawCircle(
+      Offset(size.width * .84, size.height * .10),
+      90,
+      glowPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _WeatherAtmospherePainter oldDelegate) {
+    return mood != oldDelegate.mood || dark != oldDelegate.dark;
   }
 }
 
@@ -3231,60 +3584,92 @@ class _HomeAudioPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
-    final content = Row(
-      children: [
-        Container(
-          width: 48,
-          height: 48,
-          decoration: BoxDecoration(
-            color: OSColors.indigo.withValues(alpha: 0.16),
-            borderRadius: BorderRadius.circular(18),
-            border: Border.all(
-              color: OSColors.indigo.withValues(alpha: 0.22),
-            ),
-          ),
-          child: const Icon(
-            Icons.graphic_eq_rounded,
-            color: OSColors.indigo,
-          ),
+    final content = Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        gradient: LinearGradient(
+          colors: dark
+              ? const [Color(0xFF151B2D), Color(0xFF0F172A)]
+              : const [Color(0xFFFFFFFF), Color(0xFFEFF5FF)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
         ),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+        border: Border.all(
+          color: dark
+              ? Colors.white.withValues(alpha: 0.075)
+              : Colors.white.withValues(alpha: 0.80),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
             children: [
-              const _PanelEyebrow(label: 'Focus Audio'),
-              const SizedBox(height: 6),
-              Text(
-                'Classroom sound',
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontSize: 16,
-                  fontWeight: FontWeight.w800,
-                  color: OSColors.text(dark),
+              const _AudioArtwork(),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const _PanelEyebrow(label: 'Focus Audio'),
+                    const SizedBox(height: 6),
+                    Text(
+                      'Classroom sound',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w800,
+                        color: OSColors.text(dark),
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      'Stations for quiet work and transitions.',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 12,
+                        height: 1.35,
+                        color: OSColors.textSecondary(dark),
+                      ),
+                    ),
+                  ],
                 ),
               ),
-              const SizedBox(height: 3),
-              Text(
-                'Open stations and quiet focus audio.',
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                style: TextStyle(
-                  fontSize: 12,
-                  height: 1.35,
-                  color: OSColors.textSecondary(dark),
+              Container(
+                width: 34,
+                height: 34,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: OSColors.indigo.withValues(alpha: dark ? 0.22 : 0.14),
+                  border: Border.all(
+                    color: OSColors.indigo.withValues(alpha: 0.20),
+                  ),
+                ),
+                child: const Icon(
+                  Icons.play_arrow_rounded,
+                  size: 21,
+                  color: OSColors.indigo,
                 ),
               ),
             ],
           ),
-        ),
-        Icon(
-          Icons.chevron_right_rounded,
-          size: 20,
-          color: OSColors.textMuted(dark),
-        ),
-      ],
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              const Expanded(child: _MiniEqualizer()),
+              const SizedBox(width: 12),
+              Icon(
+                Icons.chevron_right_rounded,
+                size: 20,
+                color: OSColors.textMuted(dark),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
 
     return OSTouchFeedback(
@@ -3299,6 +3684,93 @@ class _HomeAudioPanel extends StatelessWidget {
               padding: const EdgeInsets.all(16),
               child: content,
             ),
+    );
+  }
+}
+
+class _AudioArtwork extends StatelessWidget {
+  const _AudioArtwork();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 54,
+      height: 54,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(18),
+        gradient: const LinearGradient(
+          colors: [Color(0xFF4F46E5), Color(0xFF06B6D4)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: OSColors.indigo.withValues(alpha: 0.18),
+            blurRadius: 18,
+            offset: const Offset(0, 9),
+          ),
+        ],
+      ),
+      child: Stack(
+        children: [
+          Positioned(
+            right: -12,
+            top: -10,
+            child: Container(
+              width: 42,
+              height: 42,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white.withValues(alpha: 0.18),
+              ),
+            ),
+          ),
+          const Center(
+            child: Icon(
+              Icons.graphic_eq_rounded,
+              color: Colors.white,
+              size: 27,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MiniEqualizer extends StatelessWidget {
+  const _MiniEqualizer();
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    final bars = [0.32, 0.74, 0.48, 0.88, 0.42, 0.68, 0.36, 0.58];
+
+    return SizedBox(
+      height: 22,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          for (int index = 0; index < bars.length; index++) ...[
+            Expanded(
+              child: Align(
+                alignment: Alignment.bottomCenter,
+                child: FractionallySizedBox(
+                  heightFactor: bars[index],
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: OSRadius.pillBr,
+                      color: (index.isEven ? OSColors.indigo : OSColors.cyan)
+                          .withValues(alpha: dark ? 0.58 : 0.68),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            if (index != bars.length - 1) const SizedBox(width: 4),
+          ],
+        ],
+      ),
     );
   }
 }
@@ -3821,6 +4293,16 @@ String _formatLongDate(DateTime now) {
   return '${weekdays[now.weekday - 1]}, ${months[now.month - 1]} ${now.day}';
 }
 
+Color _classAccent(int index) {
+  const accents = [
+    OSColors.green,
+    OSColors.blue,
+    OSColors.cyan,
+    OSColors.indigo,
+  ];
+  return accents[index % accents.length];
+}
+
 IconData _weatherIcon(int code) {
   if (code == 0) return Icons.wb_sunny_outlined;
   if (code <= 3) return Icons.cloud_queue_rounded;
@@ -3830,6 +4312,58 @@ IconData _weatherIcon(int code) {
   if (code >= 80 && code <= 82) return Icons.water_drop_outlined;
   if (code >= 95) return Icons.thunderstorm_outlined;
   return Icons.cloud_outlined;
+}
+
+_WeatherMood _weatherMood(int? code, DateTime now, bool dark) {
+  if (code == null) return dark ? _WeatherMood.night : _WeatherMood.cloudy;
+  final isNight = dark || now.hour < 6 || now.hour >= 18;
+  if (isNight && code <= 3) return _WeatherMood.night;
+  if (code == 0) return _WeatherMood.sunny;
+  if (code <= 3 || code == 45 || code == 48) return _WeatherMood.cloudy;
+  if (code >= 51 && code <= 99) return _WeatherMood.rain;
+  return isNight ? _WeatherMood.night : _WeatherMood.cloudy;
+}
+
+List<Color> _weatherGradient(_WeatherMood mood, bool dark) {
+  return switch (mood) {
+    _WeatherMood.rain => dark
+        ? const [Color(0xFF07111D), Color(0xFF0E2A44), Color(0xFF0F172A)]
+        : const [Color(0xFFDDEBFA), Color(0xFFBBD7F0), Color(0xFFEAF5FF)],
+    _WeatherMood.cloudy => dark
+        ? const [Color(0xFF111827), Color(0xFF1E293B), Color(0xFF0F172A)]
+        : const [Color(0xFFE8EEF7), Color(0xFFD7E2EE), Color(0xFFF7FAFC)],
+    _WeatherMood.sunny => dark
+        ? const [Color(0xFF172033), Color(0xFF23466F), Color(0xFF0F172A)]
+        : const [Color(0xFFFFF7D6), Color(0xFFDBF3FF), Color(0xFFF8FAFC)],
+    _WeatherMood.night => const [
+        Color(0xFF020617),
+        Color(0xFF0B1F3A),
+        Color(0xFF111827),
+      ],
+  };
+}
+
+Color _weatherTextColor(_WeatherMood mood, bool dark) {
+  if (dark || mood == _WeatherMood.night || mood == _WeatherMood.rain) {
+    return const Color(0xFFF8FAFC);
+  }
+  return const Color(0xFF111827);
+}
+
+Color _weatherMutedTextColor(_WeatherMood mood, bool dark) {
+  if (dark || mood == _WeatherMood.night || mood == _WeatherMood.rain) {
+    return const Color(0xFFE2E8F0).withValues(alpha: 0.82);
+  }
+  return const Color(0xFF334155).withValues(alpha: 0.82);
+}
+
+Color _weatherAccentColor(_WeatherMood mood, bool dark) {
+  return switch (mood) {
+    _WeatherMood.rain => dark ? const Color(0xFF7DD3FC) : OSColors.blue,
+    _WeatherMood.cloudy => dark ? const Color(0xFFCBD5E1) : OSColors.blue,
+    _WeatherMood.sunny => dark ? const Color(0xFFFDE68A) : OSColors.amber,
+    _WeatherMood.night => const Color(0xFF93C5FD),
+  };
 }
 
 String _weatherLabel(int code) {
@@ -3903,4 +4437,3 @@ String _trimLine(String value, int maxLength) {
   }
   return '${normalized.substring(0, maxLength - 1)}...';
 }
-

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -1,4 +1,4 @@
-﻿// GradeFlow OS — Home Surface
+// GradeFlow OS — Home Surface
 //
 // The teacher's primary landing surface should read like an actual OS home:
 // a desktop stage, pinned apps, glanceable live signals, and secondary
@@ -401,7 +401,14 @@ class _HomeDesktopLayout extends StatefulWidget {
 }
 
 class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
+  static const String _folderTapRegionGroup = 'home-folder-workspace-desktop';
   _HomeWorkspaceFolder? _selectedFolder;
+
+  void _closeSelectedFolder() {
+    if (_selectedFolder != null) {
+      setState(() => _selectedFolder = null);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -430,10 +437,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                   height: 202,
                   child: _HomeShortcutShelf(
                     unread: widget.unread,
-                    themeMode: widget.themeMode,
-                    onAssistantTap: widget.onAssistantTap,
                     onLauncherTap: widget.onLauncherTap,
-                    onThemeTap: widget.onThemeTap,
                     compact: true,
                   ),
                 ),
@@ -463,12 +467,13 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                       reminderCount: widget.reminders.length,
                       now: widget.now,
                       compact: false,
-                      onAssistantTap: widget.onAssistantTap,
-                      onLauncherTap: widget.onLauncherTap,
                     ),
                   ),
                   const SizedBox(height: 14),
-                  _HomeWorkspaceFolderStrip(
+                  TapRegion(
+                    groupId: _folderTapRegionGroup,
+                    onTapOutside: (_) => _closeSelectedFolder(),
+                    child: _HomeWorkspaceFolderStrip(
                     selected: _selectedFolder,
                     classCount: widget.classes.length,
                     reminderCount: widget.reminders.length,
@@ -477,6 +482,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                       _selectedFolder =
                           _selectedFolder == folder ? null : folder;
                     }),
+                    ),
                   ),
                   const SizedBox(height: 14),
                   Align(
@@ -491,7 +497,10 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                             ? const _HomeCalmWorkspaceFloor(
                                 key: ValueKey('workspace-closed'),
                               )
-                            : _HomeWorkspaceFolderPanel(
+                            : TapRegion(
+                                groupId: _folderTapRegionGroup,
+                                onTapOutside: (_) => _closeSelectedFolder(),
+                                child: _HomeWorkspaceFolderPanel(
                                 key: ValueKey(_selectedFolder),
                                 folder: _selectedFolder!,
                                 primaryClass: widget.primaryClass,
@@ -500,6 +509,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                                 unread: widget.unread,
                                 totalStudents: widget.totalStudents,
                                 now: widget.now,
+                                ),
                               ),
                       ),
                     ),
@@ -1500,7 +1510,14 @@ class _HomeStackedLayout extends StatefulWidget {
 }
 
 class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
+  static const String _folderTapRegionGroup = 'home-folder-workspace-stacked';
   _HomeWorkspaceFolder? _selectedFolder;
+
+  void _closeSelectedFolder() {
+    if (_selectedFolder != null) {
+      setState(() => _selectedFolder = null);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -1534,12 +1551,13 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
             reminderCount: widget.reminders.length,
             now: widget.now,
             compact: true,
-            onAssistantTap: widget.onAssistantTap,
-            onLauncherTap: widget.onLauncherTap,
           ),
         ),
         const SizedBox(height: 14),
-        _HomeWorkspaceFolderStrip(
+        TapRegion(
+          groupId: _folderTapRegionGroup,
+          onTapOutside: (_) => _closeSelectedFolder(),
+          child: _HomeWorkspaceFolderStrip(
           selected: _selectedFolder,
           classCount: widget.classes.length,
           reminderCount: widget.reminders.length,
@@ -1547,17 +1565,25 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
           onSelected: (folder) => setState(() {
             _selectedFolder = _selectedFolder == folder ? null : folder;
           }),
+          ),
         ),
         AnimatedSwitcher(
           duration: const Duration(milliseconds: 240),
           switchInCurve: Curves.easeOutCubic,
           switchOutCurve: Curves.easeInCubic,
           child: _selectedFolder == null
-              ? const SizedBox.shrink(key: ValueKey('workspace-closed'))
-              : Padding(
-                  key: ValueKey(_selectedFolder),
-                  padding: const EdgeInsets.only(top: 14),
-                  child: _HomeWorkspaceFolderPanel(
+              ? const Padding(
+                  key: ValueKey('workspace-closed'),
+                  padding: EdgeInsets.only(top: 14),
+                  child: _HomeCalmWorkspaceFloor(),
+                )
+              : TapRegion(
+                  groupId: _folderTapRegionGroup,
+                  onTapOutside: (_) => _closeSelectedFolder(),
+                  child: Padding(
+                    key: ValueKey(_selectedFolder),
+                    padding: const EdgeInsets.only(top: 14),
+                    child: _HomeWorkspaceFolderPanel(
                     folder: _selectedFolder!,
                     primaryClass: widget.primaryClass,
                     classes: widget.classes,
@@ -1565,16 +1591,14 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
                     unread: widget.unread,
                     totalStudents: widget.totalStudents,
                     now: widget.now,
+                    ),
                   ),
                 ),
         ),
         const SizedBox(height: 16),
         _HomeShortcutShelf(
           unread: widget.unread,
-          themeMode: widget.themeMode,
-          onAssistantTap: widget.onAssistantTap,
           onLauncherTap: widget.onLauncherTap,
-          onThemeTap: widget.onThemeTap,
         ),
         const SizedBox(height: 16),
         _HomeUtilityRail(
@@ -2098,7 +2122,7 @@ class _HomeSystemStrip extends StatelessWidget {
                       Text(
                         teacherName.isEmpty
                             ? schoolName
-                            : '$teacherName · $schoolName',
+                            : '$teacherName Ãƒâ€šÃ‚Â· $schoolName',
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
@@ -2406,8 +2430,6 @@ class _HomeStagePanel extends StatelessWidget {
     required this.reminderCount,
     required this.now,
     required this.compact,
-    required this.onAssistantTap,
-    required this.onLauncherTap,
   });
 
   final String teacherName;
@@ -2420,8 +2442,6 @@ class _HomeStagePanel extends StatelessWidget {
   final int reminderCount;
   final DateTime now;
   final bool compact;
-  final VoidCallback onAssistantTap;
-  final VoidCallback onLauncherTap;
 
   @override
   Widget build(BuildContext context) {
@@ -2441,46 +2461,6 @@ class _HomeStagePanel extends StatelessWidget {
       begin: Alignment.topLeft,
       end: Alignment.bottomRight,
     );
-    final actions = [
-      _StageActionData(
-        label: 'Teach',
-        icon: Icons.cast_for_education_rounded,
-        accent: OSColors.blue,
-        filled: true,
-        onTap: () => context.go(AppRoutes.osTeach),
-      ),
-      _StageActionData(
-        label: 'Planner',
-        icon: Icons.calendar_month_rounded,
-        accent: OSColors.amber,
-        onTap: () => context.go(AppRoutes.osPlanner),
-      ),
-      _StageActionData(
-        label: 'Classes',
-        icon: Icons.class_rounded,
-        accent: OSColors.green,
-        onTap: () => context.go(AppRoutes.classes),
-      ),
-      _StageActionData(
-        label: unread == 0 ? 'Messages' : 'Messages $unread',
-        icon: Icons.forum_rounded,
-        accent: OSColors.cyan,
-        onTap: () => context.go(AppRoutes.communication),
-      ),
-      _StageActionData(
-        label: 'Assistant',
-        icon: Icons.auto_awesome_rounded,
-        accent: OSColors.indigo,
-        onTap: onAssistantTap,
-      ),
-      _StageActionData(
-        label: 'Launcher',
-        icon: Icons.grid_view_rounded,
-        accent: OSColors.amber,
-        onTap: onLauncherTap,
-      ),
-    ];
-
     return _GlassPanel(
       tone: _HomePanelTone.stage,
       radius: compact ? WorkspaceRadius.shellCompact : WorkspaceRadius.shell,
@@ -2581,8 +2561,6 @@ class _HomeStagePanel extends StatelessWidget {
                       ),
                     ],
                   ),
-                  const SizedBox(height: 14),
-                  _StageActionCarousel(actions: actions),
                 ],
               ),
             )
@@ -2594,7 +2572,6 @@ class _HomeStagePanel extends StatelessWidget {
               classCount: classCount,
               unread: unread,
               now: now,
-              actions: actions,
             ),
     );
   }
@@ -2609,7 +2586,6 @@ class _DesktopStageShell extends StatelessWidget {
     required this.classCount,
     required this.unread,
     required this.now,
-    required this.actions,
   });
 
   final String teacherName;
@@ -2619,7 +2595,6 @@ class _DesktopStageShell extends StatelessWidget {
   final int classCount;
   final int unread;
   final DateTime now;
-  final List<_StageActionData> actions;
 
   @override
   Widget build(BuildContext context) {
@@ -2718,8 +2693,6 @@ class _DesktopStageShell extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 10),
-        _StageActionCarousel(actions: actions),
       ],
     );
   }
@@ -2753,66 +2726,6 @@ class _StageStatusChip extends StatelessWidget {
           context,
           color: OSColors.textSecondary(dark),
         )?.copyWith(fontSize: 11),
-      ),
-    );
-  }
-}
-
-class _StageActionData {
-  const _StageActionData({
-    required this.label,
-    required this.icon,
-    required this.accent,
-    required this.onTap,
-    this.filled = false,
-  });
-
-  final String label;
-  final IconData icon;
-  final Color accent;
-  final VoidCallback onTap;
-  final bool filled;
-}
-
-class _StageActionCarousel extends StatelessWidget {
-  const _StageActionCarousel({required this.actions});
-
-  final List<_StageActionData> actions;
-
-  @override
-  Widget build(BuildContext context) {
-    return ShaderMask(
-      shaderCallback: (rect) {
-        return LinearGradient(
-          colors: [
-            Colors.transparent,
-            Colors.black,
-            Colors.black,
-            Colors.transparent,
-          ],
-          stops: const [0.0, 0.04, 0.92, 1.0],
-        ).createShader(rect);
-      },
-      blendMode: BlendMode.dstIn,
-      child: SizedBox(
-        height: 44,
-        child: ListView.separated(
-          padding: const EdgeInsets.symmetric(horizontal: 2),
-          scrollDirection: Axis.horizontal,
-          physics: const BouncingScrollPhysics(),
-          itemCount: actions.length,
-          separatorBuilder: (_, __) => const SizedBox(width: 9),
-          itemBuilder: (context, index) {
-            final action = actions[index];
-            return _StageActionButton(
-              label: action.label,
-              icon: action.icon,
-              accent: action.accent,
-              filled: action.filled,
-              onTap: action.onTap,
-            );
-          },
-        ),
       ),
     );
   }
@@ -2923,103 +2836,23 @@ class _StageSpotlightTile extends StatelessWidget {
   }
 }
 
-class _StageActionButton extends StatelessWidget {
-  const _StageActionButton({
-    required this.label,
-    required this.icon,
-    required this.accent,
-    required this.onTap,
-    this.filled = false,
-  });
-
-  final String label;
-  final IconData icon;
-  final Color accent;
-  final VoidCallback onTap;
-  final bool filled;
-
-  @override
-  Widget build(BuildContext context) {
-    final dark = context.isDark;
-
-    return OSTouchFeedback(
-      onTap: onTap,
-      borderRadius: OSRadius.pillBr,
-      minSize: const Size(104, 36),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 11, vertical: 9),
-        decoration: BoxDecoration(
-          gradient: filled
-              ? LinearGradient(
-                  colors: [accent, accent.withValues(alpha: 0.72)],
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                )
-              : null,
-          color: filled
-              ? null
-              : (dark
-                  ? Colors.white.withValues(alpha: 0.04)
-                  : Colors.white.withValues(alpha: 0.50)),
-          borderRadius: OSRadius.pillBr,
-          border: Border.all(
-            color: filled
-                ? Colors.white.withValues(alpha: 0.08)
-                : (dark
-                    ? Colors.white.withValues(alpha: 0.06)
-                    : Colors.white.withValues(alpha: 0.56)),
-          ),
-        ),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              icon,
-              size: 14,
-              color: filled ? Colors.white : accent,
-            ),
-            const SizedBox(width: 7),
-            Text(
-              label,
-              style: TextStyle(
-                fontSize: 11,
-                fontWeight: FontWeight.w700,
-                color: filled ? Colors.white : OSColors.text(dark),
-              ),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
 class _HomeShortcutShelf extends StatelessWidget {
   const _HomeShortcutShelf({
     required this.unread,
-    required this.themeMode,
-    required this.onAssistantTap,
     required this.onLauncherTap,
-    required this.onThemeTap,
     this.compact = false,
   });
 
   final int unread;
-  final ThemeMode themeMode;
-  final VoidCallback onAssistantTap;
   final VoidCallback onLauncherTap;
-  final VoidCallback onThemeTap;
   final bool compact;
 
   @override
   Widget build(BuildContext context) {
+    final showLauncher = MediaQuery.sizeOf(context).width < 560;
     final shortcuts = <_HomeShortcutData>[
       _shortcutFromApp(OSAppId.teach,
           onTap: () => context.go(AppRoutes.osTeach)),
-      _shortcutFromApp(OSAppId.planner,
-          onTap: () => context.go(AppRoutes.osPlanner)),
-      _shortcutFromApp(OSAppId.classes,
-          onTap: () => context.go(AppRoutes.classes)),
       _shortcutFromApp(
         OSAppId.whiteboard,
         onTap: () => context.push(AppRoutes.whiteboard),
@@ -3029,26 +2862,13 @@ class _HomeShortcutShelf extends StatelessWidget {
         onTap: () => context.go(AppRoutes.communication),
         badge: unread > 0 ? '$unread' : null,
       ),
-      _HomeShortcutData(
-        label: 'Assistant',
-        icon: Icons.auto_awesome_rounded,
-        accent: OSColors.indigo,
-        onTap: onAssistantTap,
-      ),
-      _HomeShortcutData(
-        label: 'Launcher',
-        icon: Icons.grid_view_rounded,
-        accent: OSColors.amber,
-        onTap: onLauncherTap,
-      ),
-      _HomeShortcutData(
-        label: themeMode == ThemeMode.light ? 'Dark mode' : 'Light mode',
-        icon: themeMode == ThemeMode.light
-            ? Icons.dark_mode_rounded
-            : Icons.light_mode_rounded,
-        accent: OSColors.blue,
-        onTap: onThemeTap,
-      ),
+      if (showLauncher)
+        _HomeShortcutData(
+          label: 'Launcher',
+          icon: Icons.grid_view_rounded,
+          accent: OSColors.amber,
+          onTap: onLauncherTap,
+        ),
     ];
 
     return _GlassPanel(
@@ -4083,3 +3903,4 @@ String _trimLine(String value, int maxLength) {
   }
   return '${normalized.substring(0, maxLength - 1)}...';
 }
+

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -424,21 +424,40 @@ class _HomeDesktopLayout extends StatefulWidget {
 class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
   static const String _miniAppTapRegionGroup = 'home-mini-app-desktop';
   _HomeMiniApp? _selectedMiniApp;
+  Class? _selectedClassPreview;
 
   void _closeMiniApp() {
     if (_selectedMiniApp != null) {
-      setState(() => _selectedMiniApp = null);
+      setState(() {
+        _selectedMiniApp = null;
+        _selectedClassPreview = null;
+      });
     }
   }
 
   void _openMiniApp(_HomeMiniApp app) {
-    setState(() => _selectedMiniApp = app);
+    setState(() {
+      _selectedMiniApp = app;
+      if (app != _HomeMiniApp.classes) {
+        _selectedClassPreview = null;
+      }
+    });
+  }
+
+  void _openDesktopClassPreview(Class classItem) {
+    setState(() {
+      _selectedMiniApp = _HomeMiniApp.classes;
+      _selectedClassPreview = classItem;
+    });
   }
 
   void _toggleFolder(_HomeWorkspaceFolder folder) {
     final app = _miniAppForFolder(folder);
     setState(() {
       _selectedMiniApp = _selectedMiniApp == app ? null : app;
+      if (app != _HomeMiniApp.classes || _selectedMiniApp == null) {
+        _selectedClassPreview = null;
+      }
     });
   }
 
@@ -476,7 +495,10 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
               ),
               const SizedBox(height: 14),
               Expanded(
-                child: _HomeQuickClassesStrip(classes: widget.classes),
+                child: _HomeQuickClassesStrip(
+                  classes: widget.classes,
+                  onClassPreview: _openDesktopClassPreview,
+                ),
               ),
             ],
           ),
@@ -546,6 +568,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                                     unread: widget.unread,
                                     totalStudents: widget.totalStudents,
                                     now: widget.now,
+                                    selectedClass: _selectedClassPreview,
                                     onClose: _closeMiniApp,
                                   ),
                                 ),
@@ -842,17 +865,19 @@ class _HomeMessagesWidget extends StatelessWidget {
             ),
           ),
         ),
-        SizedBox(height: compact ? 8 : 12),
-        _FolderMessagePreview(
-          sender: unread == 0 ? 'Staff room' : 'Unread channels',
-          snippet: unread == 0
-              ? 'Recent class and staff threads are ready.'
-              : '$unread conversation${unread == 1 ? '' : 's'} waiting for review.',
-          status: unread == 0 ? 'quiet' : 'now',
-          unread: unread > 0,
-          accent: OSColors.cyan,
-          onTap: onTap,
-        ),
+        if (!compact) ...[
+          const SizedBox(height: 12),
+          _FolderMessagePreview(
+            sender: unread == 0 ? 'Staff room' : 'Unread channels',
+            snippet: unread == 0
+                ? 'Recent class and staff threads are ready.'
+                : '$unread conversation${unread == 1 ? '' : 's'} waiting for review.',
+            status: unread == 0 ? 'quiet' : 'now',
+            unread: unread > 0,
+            accent: OSColors.cyan,
+            onTap: onTap,
+          ),
+        ],
         if (!compact) ...[
           const SizedBox(height: 8),
           _FolderMessagePreview(
@@ -869,9 +894,13 @@ class _HomeMessagesWidget extends StatelessWidget {
 }
 
 class _HomeQuickClassesStrip extends StatelessWidget {
-  const _HomeQuickClassesStrip({required this.classes});
+  const _HomeQuickClassesStrip({
+    required this.classes,
+    this.onClassPreview,
+  });
 
   final List<Class> classes;
+  final ValueChanged<Class>? onClassPreview;
 
   @override
   Widget build(BuildContext context) {
@@ -909,7 +938,12 @@ class _HomeQuickClassesStrip extends StatelessWidget {
                   padding: EdgeInsets.zero,
                   itemCount: visible.length,
                   itemBuilder: (context, index) {
-                    return _HomeQuickClassCard(classItem: visible[index]);
+                    return _HomeQuickClassCard(
+                      classItem: visible[index],
+                      onOpenPreview: onClassPreview == null
+                          ? null
+                          : () => onClassPreview!(visible[index]),
+                    );
                   },
                   separatorBuilder: (context, index) =>
                       const SizedBox(height: 8),
@@ -935,10 +969,12 @@ class _HomeQuickClassCard extends StatelessWidget {
   const _HomeQuickClassCard({
     required this.classItem,
     this.dense = false,
+    this.onOpenPreview,
   });
 
   final Class classItem;
   final bool dense;
+  final VoidCallback? onOpenPreview;
 
   @override
   Widget build(BuildContext context) {
@@ -946,7 +982,8 @@ class _HomeQuickClassCard extends StatelessWidget {
     final classId = classItem.classId;
 
     return OSTouchFeedback(
-      onTap: () => context.go(AppRoutes.osClassWorkspace(classId)),
+      onTap: onOpenPreview ??
+          () => context.go(AppRoutes.osClassWorkspace(classId)),
       borderRadius: BorderRadius.circular(dense ? 16 : 18),
       minSize: Size(204, dense ? 92 : 112),
       child: Container(
@@ -1011,31 +1048,37 @@ class _HomeQuickClassCard extends StatelessWidget {
             Row(
               children: [
                 _HomeQuickClassMiniAction(
+                  tooltip: 'Workspace',
                   icon: Icons.grid_view_rounded,
                   accent: OSColors.green,
                   onTap: () => context.go(AppRoutes.osClassWorkspace(classId)),
                 ),
                 _HomeQuickClassMiniAction(
+                  tooltip: 'Students',
                   icon: Icons.people_alt_outlined,
                   accent: OSColors.cyan,
                   onTap: () => context.go(AppRoutes.osClassStudents(classId)),
                 ),
                 _HomeQuickClassMiniAction(
+                  tooltip: 'Seating',
                   icon: Icons.event_seat_rounded,
                   accent: OSColors.amber,
                   onTap: () => context.go(AppRoutes.osClassSeating(classId)),
                 ),
                 _HomeQuickClassMiniAction(
+                  tooltip: 'Gradebook',
                   icon: Icons.menu_book_rounded,
                   accent: OSColors.coral,
                   onTap: () => context.go(AppRoutes.osClassGradebook(classId)),
                 ),
                 _HomeQuickClassMiniAction(
+                  tooltip: 'Schedule',
                   icon: Icons.calendar_month_outlined,
                   accent: OSColors.blue,
                   onTap: () => context.go(AppRoutes.osClassSchedule(classId)),
                 ),
                 _HomeQuickClassMiniAction(
+                  tooltip: 'Teach',
                   icon: Icons.cast_for_education_rounded,
                   accent: OSColors.indigo,
                   onTap: () {
@@ -1056,11 +1099,13 @@ class _HomeQuickClassCard extends StatelessWidget {
 
 class _HomeQuickClassMiniAction extends StatelessWidget {
   const _HomeQuickClassMiniAction({
+    required this.tooltip,
     required this.icon,
     required this.accent,
     required this.onTap,
   });
 
+  final String tooltip;
   final IconData icon;
   final Color accent;
   final VoidCallback onTap;
@@ -1072,22 +1117,25 @@ class _HomeQuickClassMiniAction extends StatelessWidget {
     return Expanded(
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 2),
-        child: OSTouchFeedback(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(999),
-          minSize: const Size(26, 28),
-          child: AspectRatio(
-            aspectRatio: 1,
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: accent.withValues(alpha: dark ? 0.10 : 0.075),
-                border: Border.all(
-                  color: accent.withValues(alpha: dark ? 0.26 : 0.18),
-                  width: 1.2,
+        child: Tooltip(
+          message: tooltip,
+          child: OSTouchFeedback(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(999),
+            minSize: const Size(26, 28),
+            child: AspectRatio(
+              aspectRatio: 1,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: accent.withValues(alpha: dark ? 0.10 : 0.075),
+                  border: Border.all(
+                    color: accent.withValues(alpha: dark ? 0.26 : 0.18),
+                    width: 1.2,
+                  ),
                 ),
+                child: Icon(icon, size: 14, color: accent),
               ),
-              child: Icon(icon, size: 14, color: accent),
             ),
           ),
         ),
@@ -1568,6 +1616,7 @@ class _HomeMiniAppWindow extends StatelessWidget {
     required this.unread,
     required this.totalStudents,
     required this.now,
+    required this.selectedClass,
     required this.onClose,
   });
 
@@ -1578,6 +1627,7 @@ class _HomeMiniAppWindow extends StatelessWidget {
   final int unread;
   final int totalStudents;
   final DateTime now;
+  final Class? selectedClass;
   final VoidCallback onClose;
 
   @override
@@ -1680,7 +1730,9 @@ class _HomeMiniAppWindow extends StatelessWidget {
           now: now,
           showClass: true,
         ),
-      _HomeMiniApp.classes => _ClassesFolderContent(classes: classes),
+      _HomeMiniApp.classes => selectedClass == null
+          ? _ClassesFolderContent(classes: classes)
+          : _ClassPreviewMiniAppContent(classItem: selectedClass!),
       _HomeMiniApp.tasks => _TasksFolderContent(reminders: reminders, now: now),
       _HomeMiniApp.insights => _InsightsFolderContent(
           classCount: classes.length,
@@ -2723,6 +2775,216 @@ class _ClassesFolderContent extends StatelessWidget {
   }
 }
 
+class _ClassPreviewMiniAppContent extends StatelessWidget {
+  const _ClassPreviewMiniAppContent({required this.classItem});
+
+  final Class classItem;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    final classId = classItem.classId;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                OSColors.green.withValues(alpha: dark ? 0.16 : 0.10),
+                OSColors.cyan.withValues(alpha: dark ? 0.08 : 0.06),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(
+              color: OSColors.green.withValues(alpha: dark ? 0.18 : 0.14),
+            ),
+          ),
+          child: Row(
+            children: [
+              const _HomeQuickClassIcon(size: 54),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const _PanelEyebrow(label: 'Class Preview'),
+                    const SizedBox(height: 6),
+                    Text(
+                      classItem.className,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 24,
+                        height: 1.0,
+                        fontWeight: FontWeight.w900,
+                        color: OSColors.text(dark),
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      '${classItem.subject} / ${classItem.term}',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                        color: OSColors.textSecondary(dark),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              _FolderActionButton(
+                label: 'Open full workspace',
+                icon: Icons.open_in_new_rounded,
+                onTap: () => context.go(AppRoutes.osClassWorkspace(classId)),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        Wrap(
+          spacing: 10,
+          runSpacing: 10,
+          children: [
+            _ClassPreviewAction(
+              label: 'Workspace',
+              icon: Icons.grid_view_rounded,
+              accent: OSColors.green,
+              onTap: () => context.go(AppRoutes.osClassWorkspace(classId)),
+            ),
+            _ClassPreviewAction(
+              label: 'Students',
+              icon: Icons.people_alt_outlined,
+              accent: OSColors.cyan,
+              onTap: () => context.go(AppRoutes.osClassStudents(classId)),
+            ),
+            _ClassPreviewAction(
+              label: 'Seating',
+              icon: Icons.event_seat_rounded,
+              accent: OSColors.amber,
+              onTap: () => context.go(AppRoutes.osClassSeating(classId)),
+            ),
+            _ClassPreviewAction(
+              label: 'Gradebook',
+              icon: Icons.menu_book_rounded,
+              accent: OSColors.coral,
+              onTap: () => context.go(AppRoutes.osClassGradebook(classId)),
+            ),
+            _ClassPreviewAction(
+              label: 'Schedule',
+              icon: Icons.calendar_month_outlined,
+              accent: OSColors.blue,
+              onTap: () => context.go(AppRoutes.osClassSchedule(classId)),
+            ),
+            _ClassPreviewAction(
+              label: 'Teach',
+              icon: Icons.cast_for_education_rounded,
+              accent: OSColors.indigo,
+              onTap: () {
+                context
+                    .read<GradeFlowOSController>()
+                    .setSurface(OSSurface.teach, classId: classId);
+                context.go(AppRoutes.osTeach);
+              },
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final cards = [
+              _FolderMetric(
+                label: 'Students',
+                value: 'Roster',
+                accent: OSColors.cyan,
+                onTap: () => context.go(AppRoutes.osClassStudents(classId)),
+              ),
+              _FolderMetric(
+                label: 'Seating',
+                value: 'Room',
+                accent: OSColors.amber,
+                onTap: () => context.go(AppRoutes.osClassSeating(classId)),
+              ),
+              _FolderMetric(
+                label: 'Gradebook',
+                value: 'Scores',
+                accent: OSColors.coral,
+                onTap: () => context.go(AppRoutes.osClassGradebook(classId)),
+              ),
+              _FolderMetric(
+                label: 'Schedule',
+                value: 'Plan',
+                accent: OSColors.blue,
+                onTap: () => context.go(AppRoutes.osClassSchedule(classId)),
+              ),
+            ];
+            return Wrap(spacing: 10, runSpacing: 10, children: cards);
+          },
+        ),
+      ],
+    );
+  }
+}
+
+class _ClassPreviewAction extends StatelessWidget {
+  const _ClassPreviewAction({
+    required this.label,
+    required this.icon,
+    required this.accent,
+    required this.onTap,
+  });
+
+  final String label;
+  final IconData icon;
+  final Color accent;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return OSTouchFeedback(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(18),
+      minSize: const Size(132, 54),
+      child: Container(
+        width: 142,
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        decoration: BoxDecoration(
+          color: dark
+              ? Colors.white.withValues(alpha: 0.035)
+              : Colors.white.withValues(alpha: 0.58),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(color: accent.withValues(alpha: 0.18)),
+        ),
+        child: Row(
+          children: [
+            Icon(icon, size: 18, color: accent),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w900,
+                  color: OSColors.text(dark),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _TasksFolderContent extends StatelessWidget {
   const _TasksFolderContent({
     required this.reminders,
@@ -3296,20 +3558,43 @@ class _HomeStackedLayout extends StatefulWidget {
 class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
   static const String _miniAppTapRegionGroup = 'home-mini-app-stacked';
   _HomeMiniApp? _selectedMiniApp;
+  Class? _selectedClassPreview;
 
   void _closeMiniApp() {
     if (_selectedMiniApp != null) {
-      setState(() => _selectedMiniApp = null);
+      setState(() {
+        _selectedMiniApp = null;
+        _selectedClassPreview = null;
+      });
     }
   }
 
   void _openMiniApp(_HomeMiniApp app) {
-    setState(() => _selectedMiniApp = app);
+    setState(() {
+      _selectedMiniApp = app;
+      if (app != _HomeMiniApp.classes) {
+        _selectedClassPreview = null;
+      }
+    });
+  }
+
+  // Reserved for stacked class previews if quick classes move into compact home.
+  // ignore: unused_element
+  void _openClassPreview(Class classItem) {
+    setState(() {
+      _selectedMiniApp = _HomeMiniApp.classes;
+      _selectedClassPreview = classItem;
+    });
   }
 
   void _toggleFolder(_HomeWorkspaceFolder folder) {
     final app = _miniAppForFolder(folder);
-    setState(() => _selectedMiniApp = _selectedMiniApp == app ? null : app);
+    setState(() {
+      _selectedMiniApp = _selectedMiniApp == app ? null : app;
+      if (app != _HomeMiniApp.classes || _selectedMiniApp == null) {
+        _selectedClassPreview = null;
+      }
+    });
   }
 
   @override
@@ -3382,6 +3667,7 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
                       unread: widget.unread,
                       totalStudents: widget.totalStudents,
                       now: widget.now,
+                      selectedClass: _selectedClassPreview,
                       onClose: _closeMiniApp,
                     ),
                   ),
@@ -5423,7 +5709,7 @@ class _HomeAudioPanel extends StatelessWidget {
     return OSTouchFeedback(
       onTap: onTap,
       borderRadius: BorderRadius.circular(28),
-      minSize: const Size(180, 118),
+      minSize: Size(180, compact ? 92 : 118),
       child: embedded
           ? _RailSection(child: content)
           : _GlassPanel(
@@ -5642,7 +5928,15 @@ class _HomeAgendaPanel extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               ...headerChildren,
-              if (reminders.isEmpty)
+              if (compact)
+                _StatusPill(
+                  label: reminders.isEmpty
+                      ? 'Planner clear'
+                      : _relativeReminderLabel(
+                          visibleReminders.first, DateTime.now()),
+                  accent: reminders.isEmpty ? OSColors.green : OSColors.amber,
+                )
+              else if (reminders.isEmpty)
                 const _AgendaEmptyState()
               else
                 Column(

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -726,7 +726,7 @@ class _HomeQuickClassCard extends StatelessWidget {
     return OSTouchFeedback(
       onTap: () => context.go(AppRoutes.osClassWorkspace(classId)),
       borderRadius: BorderRadius.circular(18),
-      minSize: const Size(204, 68),
+      minSize: const Size(204, 112),
       child: Container(
         padding: const EdgeInsets.fromLTRB(10, 10, 10, 10),
         decoration: BoxDecoration(
@@ -740,48 +740,134 @@ class _HomeQuickClassCard extends StatelessWidget {
                 : Colors.white.withValues(alpha: 0.64),
           ),
         ),
-        child: Row(
+        child: Column(
           children: [
-            const _HomeQuickClassIcon(),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    classItem.className,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 14,
-                      height: 1.05,
-                      fontWeight: FontWeight.w900,
-                      color: OSColors.text(dark),
-                    ),
+            Row(
+              children: [
+                const _HomeQuickClassIcon(),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        classItem.className,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 14,
+                          height: 1.05,
+                          fontWeight: FontWeight.w900,
+                          color: OSColors.text(dark),
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        classItem.subject,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 12,
+                          height: 1.05,
+                          fontWeight: FontWeight.w600,
+                          color: OSColors.textSecondary(dark),
+                        ),
+                      ),
+                    ],
                   ),
-                  const SizedBox(height: 4),
-                  Text(
-                    classItem.subject,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 12,
-                      height: 1.05,
-                      fontWeight: FontWeight.w600,
-                      color: OSColors.textSecondary(dark),
-                    ),
-                  ),
-                ],
-              ),
+                ),
+                const SizedBox(width: 8),
+                Icon(
+                  Icons.chevron_right_rounded,
+                  size: 20,
+                  color: OSColors.textMuted(dark),
+                ),
+              ],
             ),
-            const SizedBox(width: 8),
-            Icon(
-              Icons.chevron_right_rounded,
-              size: 20,
-              color: OSColors.textMuted(dark),
+            const SizedBox(height: 10),
+            Row(
+              children: [
+                _HomeQuickClassMiniAction(
+                  icon: Icons.grid_view_rounded,
+                  accent: OSColors.green,
+                  onTap: () => context.go(AppRoutes.osClassWorkspace(classId)),
+                ),
+                _HomeQuickClassMiniAction(
+                  icon: Icons.people_alt_outlined,
+                  accent: OSColors.cyan,
+                  onTap: () => context.go(AppRoutes.osClassStudents(classId)),
+                ),
+                _HomeQuickClassMiniAction(
+                  icon: Icons.event_seat_rounded,
+                  accent: OSColors.amber,
+                  onTap: () => context.go(AppRoutes.osClassSeating(classId)),
+                ),
+                _HomeQuickClassMiniAction(
+                  icon: Icons.menu_book_rounded,
+                  accent: OSColors.coral,
+                  onTap: () => context.go(AppRoutes.osClassGradebook(classId)),
+                ),
+                _HomeQuickClassMiniAction(
+                  icon: Icons.calendar_month_outlined,
+                  accent: OSColors.blue,
+                  onTap: () => context.go(AppRoutes.osClassSchedule(classId)),
+                ),
+                _HomeQuickClassMiniAction(
+                  icon: Icons.cast_for_education_rounded,
+                  accent: OSColors.indigo,
+                  onTap: () {
+                    context
+                        .read<GradeFlowOSController>()
+                        .setSurface(OSSurface.teach, classId: classId);
+                    context.go(AppRoutes.osTeach);
+                  },
+                ),
+              ],
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeQuickClassMiniAction extends StatelessWidget {
+  const _HomeQuickClassMiniAction({
+    required this.icon,
+    required this.accent,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final Color accent;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+
+    return Expanded(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 2),
+        child: OSTouchFeedback(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(999),
+          minSize: const Size(26, 28),
+          child: AspectRatio(
+            aspectRatio: 1,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: accent.withValues(alpha: dark ? 0.10 : 0.075),
+                border: Border.all(
+                  color: accent.withValues(alpha: dark ? 0.26 : 0.18),
+                  width: 1.2,
+                ),
+              ),
+              child: Icon(icon, size: 14, color: accent),
+            ),
+          ),
         ),
       ),
     );
@@ -878,7 +964,7 @@ class _HomeQuickClassEmptyCard extends StatelessWidget {
                       color: OSColors.text(dark),
                     ),
                   ),
-                  const SizedBox(height: 6),
+                  const SizedBox(height: 4),
                   Text(
                     'Set up the first workspace',
                     maxLines: 2,
@@ -3610,60 +3696,108 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
         final mutedOnWeather = _weatherMutedTextColor(mood, dark);
         final iconOnWeather = _weatherAccentColor(mood, dark);
 
+        final tempLabel = hasError
+            ? '--'
+            : loading
+                ? '--'
+                : '${data!.temperatureC.round()}°';
+        final conditionLabel = hasError
+            ? 'Forecast unavailable'
+            : loading
+                ? 'Checking forecast'
+                : _weatherLabel(data!.weatherCode);
+        final locationLabel = hasError
+            ? 'Weather will return when the network responds.'
+            : loading
+                ? 'Taichung City'
+                : '${data!.locationName} / feels like ${data.apparentTempC.round()}°';
+
         final content = Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Row(
               children: [
-                const Expanded(
-                  child: _PanelEyebrow(label: 'Local Conditions'),
+                Expanded(
+                  child: Text(
+                    'Local conditions'.toUpperCase(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: WorkspaceTypography.eyebrow(context)?.copyWith(
+                      color: textOnWeather.withValues(alpha: 0.72),
+                    ),
+                  ),
                 ),
                 Icon(
                   data == null
                       ? Icons.cloud_queue_rounded
                       : _weatherIcon(data.weatherCode),
-                  color: iconOnWeather,
-                  size: 20,
+                  color: iconOnWeather.withValues(alpha: 0.96),
+                  size: 24,
                 ),
               ],
             ),
-            const SizedBox(height: 12),
-            Text(
-              hasError
-                  ? 'Forecast unavailable'
-                  : loading
-                      ? 'Checking forecast'
-                      : '${data!.temperatureC.round()} C ${_weatherLabel(data.weatherCode)}',
-              style: TextStyle(
-                fontSize: 18,
-                height: 1.1,
-                fontWeight: FontWeight.w800,
-                color: textOnWeather,
-              ),
-            ),
-            const SizedBox(height: 5),
-            Text(
-              hasError
-                  ? 'Weather will return when the network responds.'
-                  : loading
-                      ? 'Taichung City'
-                      : '${data!.locationName} - feels like ${data.apparentTempC.round()} C',
-              maxLines: 2,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontSize: 12,
-                height: 1.4,
-                color: mutedOnWeather,
-              ),
+            const SizedBox(height: 18),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  tempLabel,
+                  style: TextStyle(
+                    fontSize: 46,
+                    height: 0.92,
+                    fontWeight: FontWeight.w900,
+                    color: textOnWeather,
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.only(bottom: 4),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          conditionLabel,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 17,
+                            height: 1.08,
+                            fontWeight: FontWeight.w900,
+                            color: textOnWeather,
+                          ),
+                        ),
+                        const SizedBox(height: 5),
+                        Text(
+                          locationLabel,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            fontSize: 11.5,
+                            height: 1.25,
+                            fontWeight: FontWeight.w600,
+                            color: mutedOnWeather,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
             ),
             if (forecast.isNotEmpty) ...[
-              const SizedBox(height: 12),
+              const SizedBox(height: 18),
               Row(
                 children: [
                   for (int index = 0; index < forecast.length; index++) ...[
                     if (index > 0) const SizedBox(width: 8),
                     Expanded(
-                      child: _WeatherForecastTile(day: forecast[index]),
+                      child: _WeatherForecastTile(
+                        day: forecast[index],
+                        textColor: textOnWeather,
+                        mutedColor: mutedOnWeather,
+                        iconColor: iconOnWeather,
+                      ),
                     ),
                   ],
                 ],
@@ -3699,42 +3833,45 @@ class _WeatherWidgetFrame extends StatelessWidget {
     final dark = context.isDark;
     final radius = BorderRadius.circular(embedded ? 24 : 28);
 
-    return Container(
-      padding: const EdgeInsets.all(14),
-      decoration: BoxDecoration(
-        borderRadius: radius,
-        gradient: LinearGradient(
-          colors: _weatherGradient(mood, dark),
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        border: Border.all(
-          color: Colors.white.withValues(alpha: dark ? 0.10 : 0.48),
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: _weatherAccentColor(mood, dark).withValues(
-              alpha: dark ? 0.12 : 0.10,
-            ),
-            blurRadius: 24,
-            offset: const Offset(0, 12),
+    return ConstrainedBox(
+      constraints: BoxConstraints(minHeight: embedded ? 214 : 220),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          borderRadius: radius,
+          gradient: LinearGradient(
+            colors: _weatherGradient(mood, dark),
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
           ),
-        ],
-      ),
-      child: ClipRRect(
-        borderRadius: radius,
-        child: Stack(
-          children: [
-            Positioned.fill(
-              child: CustomPaint(
-                painter: _WeatherAtmospherePainter(
-                  mood: mood,
-                  dark: dark,
+          border: Border.all(
+            color: Colors.white.withValues(alpha: dark ? 0.12 : 0.54),
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: _weatherAccentColor(mood, dark).withValues(
+                alpha: dark ? 0.18 : 0.16,
+              ),
+              blurRadius: 30,
+              offset: const Offset(0, 15),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: radius,
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: CustomPaint(
+                  painter: _WeatherAtmospherePainter(
+                    mood: mood,
+                    dark: dark,
+                  ),
                 ),
               ),
-            ),
-            child,
-          ],
+              child,
+            ],
+          ),
         ),
       ),
     );
@@ -3816,6 +3953,30 @@ class _WeatherAtmospherePainter extends CustomPainter {
       return;
     }
 
+    if (mood == _WeatherMood.night) {
+      final moon = Paint()
+        ..color = Colors.white.withValues(alpha: dark ? 0.26 : 0.22);
+      canvas.drawCircle(Offset(size.width * .84, size.height * .14), 22, moon);
+      final cutout = Paint()
+        ..color = const Color(0xFF0B1F3A).withValues(alpha: 0.76);
+      canvas.drawCircle(
+        Offset(size.width * .91, size.height * .10),
+        20,
+        cutout,
+      );
+      final star = Paint()
+        ..style = PaintingStyle.fill
+        ..color = Colors.white.withValues(alpha: 0.32);
+      for (final offset in [
+        Offset(size.width * .18, size.height * .16),
+        Offset(size.width * .34, size.height * .30),
+        Offset(size.width * .72, size.height * .40),
+      ]) {
+        canvas.drawCircle(offset, 1.4, star);
+      }
+      return;
+    }
+
     final sun = Paint()
       ..color = Colors.white.withValues(
         alpha: mood == _WeatherMood.night ? 0.16 : 0.34,
@@ -3840,9 +4001,17 @@ class _WeatherAtmospherePainter extends CustomPainter {
 }
 
 class _WeatherForecastTile extends StatelessWidget {
-  const _WeatherForecastTile({required this.day});
+  const _WeatherForecastTile({
+    required this.day,
+    required this.textColor,
+    required this.mutedColor,
+    required this.iconColor,
+  });
 
   final DashboardForecastDay day;
+  final Color textColor;
+  final Color mutedColor;
+  final Color iconColor;
 
   @override
   Widget build(BuildContext context) {
@@ -3852,19 +4021,17 @@ class _WeatherForecastTile extends StatelessWidget {
       padding: const EdgeInsets.all(10),
       decoration: BoxDecoration(
         color: dark
-            ? Colors.white.withValues(alpha: 0.04)
-            : Colors.white.withValues(alpha: 0.64),
+            ? Colors.white.withValues(alpha: 0.075)
+            : Colors.white.withValues(alpha: 0.30),
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: dark
-              ? Colors.white.withValues(alpha: 0.06)
-              : Colors.white.withValues(alpha: 0.70),
+          color: Colors.white.withValues(alpha: dark ? 0.10 : 0.40),
         ),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(_weatherIcon(day.weatherCode), size: 16, color: OSColors.blue),
+          Icon(_weatherIcon(day.weatherCode), size: 16, color: iconColor),
           const SizedBox(height: 8),
           Text(
             _formatDateLine(day.date),
@@ -3873,7 +4040,7 @@ class _WeatherForecastTile extends StatelessWidget {
             style: TextStyle(
               fontSize: 11,
               fontWeight: FontWeight.w700,
-              color: OSColors.textMuted(dark),
+              color: mutedColor,
             ),
           ),
           const SizedBox(height: 2),
@@ -3882,7 +4049,7 @@ class _WeatherForecastTile extends StatelessWidget {
             style: TextStyle(
               fontSize: 12,
               fontWeight: FontWeight.w800,
-              color: OSColors.text(dark),
+              color: textColor,
             ),
           ),
         ],
@@ -3904,13 +4071,13 @@ class _HomeAudioPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     final dark = context.isDark;
     final content = Container(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.all(13),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(22),
         gradient: LinearGradient(
           colors: dark
-              ? const [Color(0xFF151B2D), Color(0xFF0F172A)]
-              : const [Color(0xFFFFFFFF), Color(0xFFEFF5FF)],
+              ? const [Color(0xFF1B2137), Color(0xFF101827)]
+              : const [Color(0xFFFFFFFF), Color(0xFFEAF4FF)],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),
@@ -3924,6 +4091,7 @@ class _HomeAudioPanel extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               const _AudioArtwork(),
               const SizedBox(width: 12),
@@ -3958,19 +4126,25 @@ class _HomeAudioPanel extends StatelessWidget {
                 ),
               ),
               Container(
-                width: 32,
-                height: 32,
+                width: 34,
+                height: 34,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: OSColors.indigo.withValues(alpha: dark ? 0.22 : 0.14),
-                  border: Border.all(
-                    color: OSColors.indigo.withValues(alpha: 0.20),
+                  gradient: const LinearGradient(
+                    colors: [Color(0xFF6D5DFB), Color(0xFF22D3EE)],
                   ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: OSColors.indigo.withValues(alpha: 0.18),
+                      blurRadius: 14,
+                      offset: const Offset(0, 7),
+                    ),
+                  ],
                 ),
                 child: const Icon(
                   Icons.play_arrow_rounded,
-                  size: 21,
-                  color: OSColors.indigo,
+                  size: 22,
+                  color: Colors.white,
                 ),
               ),
             ],
@@ -3993,10 +4167,18 @@ class _HomeAudioPanel extends StatelessWidget {
             children: [
               const Expanded(child: _MiniEqualizer()),
               const SizedBox(width: 12),
-              Icon(
-                Icons.chevron_right_rounded,
-                size: 20,
-                color: OSColors.textMuted(dark),
+              Container(
+                width: 24,
+                height: 24,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Colors.white.withValues(alpha: dark ? 0.055 : 0.58),
+                ),
+                child: Icon(
+                  Icons.chevron_right_rounded,
+                  size: 18,
+                  color: OSColors.textMuted(dark),
+                ),
               ),
             ],
           ),
@@ -4026,12 +4208,12 @@ class _AudioArtwork extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 48,
-      height: 48,
+      width: 50,
+      height: 50,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(16),
+        borderRadius: BorderRadius.circular(17),
         gradient: const LinearGradient(
-          colors: [Color(0xFF4F46E5), Color(0xFF06B6D4)],
+          colors: [Color(0xFF1D4ED8), Color(0xFF06B6D4), Color(0xFF67E8F9)],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),
@@ -4124,26 +4306,73 @@ class _HomeAgendaPanel extends StatelessWidget {
         scrollable ? reminders : reminders.take(4).toList();
     final dark = context.isDark;
     final headerChildren = <Widget>[
-      const _PanelEyebrow(label: 'Agenda Queue'),
-      const SizedBox(height: 8),
-      Text(
-        reminders.isEmpty ? 'Clear for now' : 'Next reminders',
-        style: TextStyle(
-          fontSize: 17,
-          fontWeight: FontWeight.w800,
-          letterSpacing: 0,
-          color: OSColors.text(dark),
-        ),
+      Row(
+        children: [
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              color: OSColors.amber.withValues(alpha: dark ? 0.13 : 0.10),
+              borderRadius: BorderRadius.circular(13),
+              border: Border.all(
+                color: OSColors.amber.withValues(alpha: 0.18),
+              ),
+            ),
+            child: const Icon(
+              Icons.event_available_rounded,
+              size: 17,
+              color: OSColors.amber,
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const _PanelEyebrow(label: 'Agenda Queue'),
+                const SizedBox(height: 3),
+                Text(
+                  reminders.isEmpty ? 'Clear for now' : 'Next reminders',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.w900,
+                    letterSpacing: 0,
+                    color: OSColors.text(dark),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
-      const SizedBox(height: 4),
-      Text(
-        reminders.isEmpty
-            ? 'The planning lane is calm.'
-            : 'Priority items stay visible without crowding the workspace.',
-        style: TextStyle(
-          fontSize: 12,
-          height: 1.45,
-          color: OSColors.textSecondary(dark),
+      const SizedBox(height: 10),
+      Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+        decoration: BoxDecoration(
+          color: dark
+              ? Colors.white.withValues(alpha: 0.030)
+              : Colors.white.withValues(alpha: 0.46),
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(
+            color: dark
+                ? Colors.white.withValues(alpha: 0.045)
+                : Colors.white.withValues(alpha: 0.58),
+          ),
+        ),
+        child: Text(
+          reminders.isEmpty
+              ? 'The planning lane is calm.'
+              : 'Priority items stay visible without crowding the workspace.',
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            fontSize: 11.5,
+            height: 1.34,
+            color: OSColors.textSecondary(dark),
+          ),
         ),
       ),
       const SizedBox(height: 10),
@@ -4312,7 +4541,7 @@ class _ReminderTile extends StatelessWidget {
     final dueLabel = _relativeReminderLabel(reminder, now);
     final accent = _reminderAccent(reminder, now);
 
-    return Container(
+    final tile = Container(
       padding: const EdgeInsets.all(11),
       decoration: BoxDecoration(
         color: dark
@@ -4392,6 +4621,13 @@ class _ReminderTile extends StatelessWidget {
           ),
         ],
       ),
+    );
+
+    return OSTouchFeedback(
+      onTap: () => context.go(AppRoutes.osPlanner),
+      borderRadius: BorderRadius.circular(18),
+      minSize: const Size(190, 78),
+      child: tile,
     );
   }
 
@@ -4696,14 +4932,14 @@ _WeatherMood _weatherMood(int? code, DateTime now, bool dark) {
 List<Color> _weatherGradient(_WeatherMood mood, bool dark) {
   return switch (mood) {
     _WeatherMood.rain => dark
-        ? const [Color(0xFF07111D), Color(0xFF0E2A44), Color(0xFF0F172A)]
-        : const [Color(0xFFDDEBFA), Color(0xFFBBD7F0), Color(0xFFEAF5FF)],
+        ? const [Color(0xFF06101F), Color(0xFF12324F), Color(0xFF0B1726)]
+        : const [Color(0xFF7FA9C7), Color(0xFFBCD2E5), Color(0xFFE7F1FA)],
     _WeatherMood.cloudy => dark
-        ? const [Color(0xFF111827), Color(0xFF1E293B), Color(0xFF0F172A)]
-        : const [Color(0xFFE8EEF7), Color(0xFFD7E2EE), Color(0xFFF7FAFC)],
+        ? const [Color(0xFF0F172A), Color(0xFF27364A), Color(0xFF111827)]
+        : const [Color(0xFFAFC4D8), Color(0xFFD8E3ED), Color(0xFFF6FAFC)],
     _WeatherMood.sunny => dark
         ? const [Color(0xFF172033), Color(0xFF23466F), Color(0xFF0F172A)]
-        : const [Color(0xFFFFF7D6), Color(0xFFDBF3FF), Color(0xFFF8FAFC)],
+        : const [Color(0xFF57A7EA), Color(0xFFB7E4FF), Color(0xFFFFE8A3)],
     _WeatherMood.night => const [
         Color(0xFF020617),
         Color(0xFF0B1F3A),

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -520,38 +520,39 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                     ),
                   ),
                   const SizedBox(height: 14),
-                  Align(
-                    alignment: Alignment.topCenter,
-                    child: ConstrainedBox(
-                      constraints: const BoxConstraints(maxWidth: 760),
-                      child: AnimatedSwitcher(
-                        duration: const Duration(milliseconds: 240),
-                        switchInCurve: Curves.easeOutCubic,
-                        switchOutCurve: Curves.easeInOut,
-                        transitionBuilder: _homeFolderTransition,
-                        child: _selectedMiniApp == null
-                            ? const _HomeCalmWorkspaceFloor(
-                                key: ValueKey('workspace-closed'),
-                              )
-                            : TapRegion(
-                                groupId: _miniAppTapRegionGroup,
-                                onTapOutside: (_) => _closeMiniApp(),
-                                child: _HomeMiniAppWindow(
-                                  key: ValueKey(_selectedMiniApp),
-                                  app: _selectedMiniApp!,
-                                  primaryClass: widget.primaryClass,
-                                  classes: widget.classes,
-                                  reminders: widget.reminders,
-                                  unread: widget.unread,
-                                  totalStudents: widget.totalStudents,
-                                  now: widget.now,
-                                  onClose: _closeMiniApp,
+                  Expanded(
+                    child: Align(
+                      alignment: Alignment.topCenter,
+                      child: ConstrainedBox(
+                        constraints: const BoxConstraints(maxWidth: 980),
+                        child: AnimatedSwitcher(
+                          duration: const Duration(milliseconds: 240),
+                          switchInCurve: Curves.easeOutCubic,
+                          switchOutCurve: Curves.easeInOut,
+                          transitionBuilder: _homeFolderTransition,
+                          child: _selectedMiniApp == null
+                              ? const _HomeCalmWorkspaceFloor(
+                                  key: ValueKey('workspace-closed'),
+                                )
+                              : TapRegion(
+                                  groupId: _miniAppTapRegionGroup,
+                                  onTapOutside: (_) => _closeMiniApp(),
+                                  child: _HomeMiniAppWindow(
+                                    key: ValueKey(_selectedMiniApp),
+                                    app: _selectedMiniApp!,
+                                    primaryClass: widget.primaryClass,
+                                    classes: widget.classes,
+                                    reminders: widget.reminders,
+                                    unread: widget.unread,
+                                    totalStudents: widget.totalStudents,
+                                    now: widget.now,
+                                    onClose: _closeMiniApp,
+                                  ),
                                 ),
-                              ),
+                        ),
                       ),
                     ),
                   ),
-                  const Spacer(),
                 ],
               );
             },
@@ -567,6 +568,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
             onAudioTap: () => _openMiniApp(_HomeMiniApp.audio),
             onMessagesTap: () => _openMiniApp(_HomeMiniApp.messages),
             onAgendaTap: () => _openMiniApp(_HomeMiniApp.agenda),
+            onWeatherTap: () => _openMiniApp(_HomeMiniApp.weather),
           ),
         ),
       ],
@@ -575,6 +577,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
 }
 
 enum _HomeMiniApp {
+  weather,
   today,
   classes,
   tasks,
@@ -601,7 +604,11 @@ _HomeWorkspaceFolder? _folderForMiniApp(_HomeMiniApp? app) {
     _HomeMiniApp.tasks => _HomeWorkspaceFolder.tasks,
     _HomeMiniApp.messages => _HomeWorkspaceFolder.messages,
     _HomeMiniApp.insights => _HomeWorkspaceFolder.insights,
-    _HomeMiniApp.agenda || _HomeMiniApp.audio || null => null,
+    _HomeMiniApp.weather ||
+    _HomeMiniApp.agenda ||
+    _HomeMiniApp.audio ||
+    null =>
+      null,
   };
 }
 
@@ -613,6 +620,7 @@ class _HomeUtilityRail extends StatelessWidget {
     required this.onAudioTap,
     required this.onMessagesTap,
     required this.onAgendaTap,
+    required this.onWeatherTap,
   });
 
   final int unread;
@@ -621,6 +629,7 @@ class _HomeUtilityRail extends StatelessWidget {
   final VoidCallback onAudioTap;
   final VoidCallback onMessagesTap;
   final VoidCallback onAgendaTap;
+  final VoidCallback onWeatherTap;
 
   @override
   Widget build(BuildContext context) {
@@ -633,7 +642,7 @@ class _HomeUtilityRail extends StatelessWidget {
     return _GlassPanel(
       tone: _HomePanelTone.rail,
       radius: 30,
-      padding: const EdgeInsets.fromLTRB(14, 14, 14, 16),
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, 12),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
@@ -680,15 +689,15 @@ class _HomeUtilityRail extends StatelessWidget {
               ],
             ),
           ),
-          const SizedBox(height: 14),
-          const _HomeWeatherPanel(embedded: true),
           const SizedBox(height: 10),
+          _HomeWeatherPanel(embedded: true, onTap: onWeatherTap),
+          const SizedBox(height: 8),
           _HomeAudioPanel(
             embedded: true,
             compact: true,
             onTap: onAudioTap,
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: 8),
           _RailSection(
             child: _HomeMessagesWidget(
               unread: unread,
@@ -696,7 +705,7 @@ class _HomeUtilityRail extends StatelessWidget {
               compact: true,
             ),
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: 8),
           _HomeAgendaPanel(
             reminders: reminders,
             scrollable: false,
@@ -1579,72 +1588,83 @@ class _HomeMiniAppWindow extends StatelessWidget {
       tone: _HomePanelTone.whisper,
       radius: 28,
       padding: const EdgeInsets.fromLTRB(14, 12, 14, 14),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(minHeight: 286, maxHeight: 520),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Row(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final maxHeight = constraints.maxHeight.isFinite
+              ? constraints.maxHeight
+              : MediaQuery.sizeOf(context).height * 0.62;
+          final preferredHeight = maxHeight.clamp(420.0, 660.0);
+          final windowHeight = maxHeight < 420 ? maxHeight : preferredHeight;
+
+          return SizedBox(
+            height: windowHeight,
+            child: Column(
               children: [
-                Container(
-                  width: 34,
-                  height: 34,
-                  decoration: BoxDecoration(
-                    color: accent.withValues(alpha: dark ? 0.16 : 0.11),
-                    borderRadius: BorderRadius.circular(13),
-                    border: Border.all(color: accent.withValues(alpha: 0.22)),
-                  ),
-                  child: Icon(_miniAppIcon(app), size: 18, color: accent),
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      const _PanelEyebrow(label: 'Mini Desktop'),
-                      const SizedBox(height: 2),
-                      Text(
-                        _miniAppTitle(app),
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          fontSize: 17,
-                          fontWeight: FontWeight.w900,
-                          color: OSColors.text(dark),
-                        ),
+                Row(
+                  children: [
+                    Container(
+                      width: 34,
+                      height: 34,
+                      decoration: BoxDecoration(
+                        color: accent.withValues(alpha: dark ? 0.16 : 0.11),
+                        borderRadius: BorderRadius.circular(13),
+                        border:
+                            Border.all(color: accent.withValues(alpha: 0.22)),
                       ),
+                      child: Icon(_miniAppIcon(app), size: 18, color: accent),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const _PanelEyebrow(label: 'Mini Desktop'),
+                          const SizedBox(height: 2),
+                          Text(
+                            _miniAppTitle(app),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontSize: 17,
+                              fontWeight: FontWeight.w900,
+                              color: OSColors.text(dark),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    if (_miniAppFullRoute(app) != null) ...[
+                      _MiniWindowIconButton(
+                        icon: Icons.open_in_new_rounded,
+                        tooltip: 'Open full page',
+                        onTap: () => context.go(_miniAppFullRoute(app)!),
+                      ),
+                      const SizedBox(width: 6),
                     ],
-                  ),
+                    _MiniWindowIconButton(
+                      icon: Icons.close_rounded,
+                      tooltip: 'Close',
+                      onTap: onClose,
+                    ),
+                  ],
                 ),
-                if (_miniAppFullRoute(app) != null) ...[
-                  _MiniWindowIconButton(
-                    icon: Icons.open_in_new_rounded,
-                    tooltip: 'Open full page',
-                    onTap: () => context.go(_miniAppFullRoute(app)!),
+                const SizedBox(height: 12),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: _miniAppBody(context),
                   ),
-                  const SizedBox(width: 6),
-                ],
-                _MiniWindowIconButton(
-                  icon: Icons.close_rounded,
-                  tooltip: 'Close',
-                  onTap: onClose,
                 ),
               ],
             ),
-            const SizedBox(height: 12),
-            Flexible(
-              child: SingleChildScrollView(
-                child: _miniAppBody(context),
-              ),
-            ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }
 
   Widget _miniAppBody(BuildContext context) {
     return switch (app) {
+      _HomeMiniApp.weather => const _WeatherMiniAppContent(),
       _HomeMiniApp.messages => _MessagesMiniAppContent(unread: unread),
       _HomeMiniApp.agenda => _AgendaMiniAppContent(
           title: 'Review today\'s plan',
@@ -1715,6 +1735,7 @@ class _MiniWindowIconButton extends StatelessWidget {
 
 String _miniAppTitle(_HomeMiniApp app) {
   return switch (app) {
+    _HomeMiniApp.weather => 'Weather',
     _HomeMiniApp.messages => 'Messages',
     _HomeMiniApp.agenda => 'Agenda / Today\'s Plan',
     _HomeMiniApp.audio => 'Focus Audio',
@@ -1727,6 +1748,7 @@ String _miniAppTitle(_HomeMiniApp app) {
 
 IconData _miniAppIcon(_HomeMiniApp app) {
   return switch (app) {
+    _HomeMiniApp.weather => Icons.wb_cloudy_rounded,
     _HomeMiniApp.messages => Icons.forum_rounded,
     _HomeMiniApp.agenda => Icons.event_available_rounded,
     _HomeMiniApp.audio => Icons.graphic_eq_rounded,
@@ -1739,6 +1761,7 @@ IconData _miniAppIcon(_HomeMiniApp app) {
 
 Color _miniAppAccent(_HomeMiniApp app) {
   return switch (app) {
+    _HomeMiniApp.weather => OSColors.blue,
     _HomeMiniApp.messages => OSColors.cyan,
     _HomeMiniApp.agenda => OSColors.amber,
     _HomeMiniApp.audio => OSColors.indigo,
@@ -1757,8 +1780,214 @@ String? _miniAppFullRoute(_HomeMiniApp app) {
     _HomeMiniApp.tasks =>
       AppRoutes.osPlanner,
     _HomeMiniApp.classes || _HomeMiniApp.insights => AppRoutes.classes,
-    _HomeMiniApp.audio => null,
+    _HomeMiniApp.weather || _HomeMiniApp.audio => null,
   };
+}
+
+class _WeatherMiniAppContent extends StatefulWidget {
+  const _WeatherMiniAppContent();
+
+  @override
+  State<_WeatherMiniAppContent> createState() => _WeatherMiniAppContentState();
+}
+
+class _WeatherMiniAppContentState extends State<_WeatherMiniAppContent> {
+  late final DashboardWeatherService _service = DashboardWeatherService();
+  late final Future<DashboardWeatherSnapshot> _weather =
+      _service.fetchForecast();
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return FutureBuilder<DashboardWeatherSnapshot>(
+      future: _weather,
+      builder: (context, snapshot) {
+        final data = snapshot.data;
+        final loading = snapshot.connectionState == ConnectionState.waiting;
+        final hasError = snapshot.hasError && data == null;
+        final mood = _weatherMood(data?.weatherCode, DateTime.now(), dark);
+        final textColor = _weatherTextColor(mood, dark);
+        final mutedColor = _weatherMutedTextColor(mood, dark);
+        final accent = _weatherAccentColor(mood, dark);
+        final forecast =
+            data?.forecast.take(5).toList() ?? const <DashboardForecastDay>[];
+        final temp =
+            hasError || loading ? '--' : '${data!.temperatureC.round()}Â°';
+        final condition = hasError
+            ? 'Forecast unavailable'
+            : loading
+                ? 'Checking forecast'
+                : _weatherLabel(data!.weatherCode);
+        final location = hasError
+            ? 'Weather will return when the network responds.'
+            : loading
+                ? 'Taichung City'
+                : data!.locationName;
+        final feelsLike = data == null
+            ? 'Feels-like unavailable'
+            : 'Feels like ${data.apparentTempC.round()}Â°';
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _WeatherWidgetFrame(
+              mood: mood,
+              embedded: false,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          location,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: WorkspaceTypography.eyebrow(context)?.copyWith(
+                              color: textColor.withValues(alpha: .74)),
+                        ),
+                      ),
+                      Icon(
+                        data == null
+                            ? Icons.cloud_queue_rounded
+                            : _weatherIcon(data.weatherCode),
+                        color: accent,
+                        size: 30,
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        temp,
+                        style: TextStyle(
+                          fontSize: 72,
+                          height: .88,
+                          fontWeight: FontWeight.w900,
+                          color: textColor,
+                        ),
+                      ),
+                      const SizedBox(width: 14),
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.only(bottom: 6),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                condition,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  fontSize: 24,
+                                  fontWeight: FontWeight.w900,
+                                  color: textColor,
+                                ),
+                              ),
+                              const SizedBox(height: 6),
+                              Text(
+                                feelsLike,
+                                style: TextStyle(
+                                  fontSize: 13,
+                                  fontWeight: FontWeight.w700,
+                                  color: mutedColor,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 18),
+                  _WeatherTeacherNote(mood: mood),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            if (forecast.isNotEmpty) ...[
+              SizedBox(
+                height: 88,
+                child: ListView.separated(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: forecast.length,
+                  separatorBuilder: (_, __) => const SizedBox(width: 10),
+                  itemBuilder: (context, index) {
+                    return SizedBox(
+                      width: 128,
+                      child: _WeatherForecastTile(
+                        day: forecast[index],
+                        textColor: OSColors.text(dark),
+                        mutedColor: OSColors.textSecondary(dark),
+                        iconColor: accent,
+                      ),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
+            _WeatherDetailGrid(
+              condition: condition,
+              feelsLike: feelsLike,
+              accent: accent,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _WeatherTeacherNote extends StatelessWidget {
+  const _WeatherTeacherNote({required this.mood});
+
+  final _WeatherMood mood;
+
+  @override
+  Widget build(BuildContext context) {
+    final note = switch (mood) {
+      _WeatherMood.rain => 'Rain signal - indoor transitions may be easier.',
+      _WeatherMood.cloudy =>
+        'Cloud cover - keep transitions calm and flexible.',
+      _WeatherMood.sunny => 'Warm afternoon - keep water nearby.',
+      _WeatherMood.night => 'Evening conditions - keep dismissal paths clear.',
+    };
+    return _StatusPill(
+        label: note, accent: _weatherAccentColor(mood, context.isDark));
+  }
+}
+
+class _WeatherDetailGrid extends StatelessWidget {
+  const _WeatherDetailGrid({
+    required this.condition,
+    required this.feelsLike,
+    required this.accent,
+  });
+
+  final String condition;
+  final String feelsLike;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 10,
+      runSpacing: 10,
+      children: [
+        _FolderMetric(label: 'Condition', value: condition, accent: accent),
+        _FolderMetric(
+            label: 'Comfort', value: feelsLike, accent: OSColors.cyan),
+        _FolderMetric(
+          label: 'Transitions',
+          value: 'Check',
+          accent: OSColors.amber,
+        ),
+      ],
+    );
+  }
 }
 
 class _MessagesMiniAppContent extends StatelessWidget {
@@ -1861,9 +2090,19 @@ class _MessagesMiniAppContent extends StatelessWidget {
               ),
               const SizedBox(height: 8),
               const _MessageBubble(
+                text: 'Class channels are ready for a quick scan from Home.',
+                incoming: true,
+              ),
+              const SizedBox(height: 8),
+              const _MessageBubble(
                 text:
                     'Open full messages when you need to reply or manage channels.',
                 incoming: false,
+              ),
+              const SizedBox(height: 8),
+              const _MessageBubble(
+                text: 'This quick view keeps the lesson surface open.',
+                incoming: true,
               ),
               const SizedBox(height: 12),
               _MiniInputBar(label: 'Reply from full Messages'),
@@ -2026,37 +2265,50 @@ class _FocusAudioMiniAppContent extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 12),
-        Row(
-          children: [
-            Expanded(child: _StationList(stations: stations)),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final signal = Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: dark
+                    ? Colors.white.withValues(alpha: 0.030)
+                    : Colors.white.withValues(alpha: 0.56),
+                borderRadius: BorderRadius.circular(22),
+                border: Border.all(
                   color: dark
-                      ? Colors.white.withValues(alpha: 0.030)
-                      : Colors.white.withValues(alpha: 0.56),
-                  borderRadius: BorderRadius.circular(22),
-                  border: Border.all(
-                    color: dark
-                        ? Colors.white.withValues(alpha: 0.055)
-                        : Colors.white.withValues(alpha: 0.68),
-                  ),
-                ),
-                child: const Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _PanelEyebrow(label: 'Signal'),
-                    SizedBox(height: 12),
-                    _MiniEqualizer(),
-                    SizedBox(height: 14),
-                    _MiniInputBar(label: 'Add station'),
-                  ],
+                      ? Colors.white.withValues(alpha: 0.055)
+                      : Colors.white.withValues(alpha: 0.68),
                 ),
               ),
-            ),
-          ],
+              child: const Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _PanelEyebrow(label: 'Signal'),
+                  SizedBox(height: 12),
+                  _MiniEqualizer(),
+                  SizedBox(height: 14),
+                  _MiniInputBar(label: 'Add station'),
+                ],
+              ),
+            );
+            if (constraints.maxWidth < 560) {
+              return Column(
+                children: [
+                  _StationList(stations: stations),
+                  const SizedBox(height: 12),
+                  signal,
+                ],
+              );
+            }
+            return Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(child: _StationList(stations: stations)),
+                const SizedBox(width: 12),
+                Expanded(child: signal),
+              ],
+            );
+          },
         ),
       ],
     );
@@ -2147,6 +2399,8 @@ class _StatusPill extends StatelessWidget {
       ),
       child: Text(
         label,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
         style: TextStyle(
           fontSize: 10.5,
           fontWeight: FontWeight.w900,
@@ -2169,7 +2423,7 @@ class _MessageBubble extends StatelessWidget {
     return Align(
       alignment: incoming ? Alignment.centerLeft : Alignment.centerRight,
       child: Container(
-        constraints: const BoxConstraints(maxWidth: 320),
+        constraints: const BoxConstraints(maxWidth: 420),
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
         decoration: BoxDecoration(
           color: incoming
@@ -3147,6 +3401,7 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
           onAudioTap: () => _openMiniApp(_HomeMiniApp.audio),
           onMessagesTap: () => _openMiniApp(_HomeMiniApp.messages),
           onAgendaTap: () => _openMiniApp(_HomeMiniApp.agenda),
+          onWeatherTap: () => _openMiniApp(_HomeMiniApp.weather),
         ),
         const SizedBox(height: 112),
       ],
@@ -4652,9 +4907,10 @@ class _HomeShortcutIcon extends StatelessWidget {
 }
 
 class _HomeWeatherPanel extends StatefulWidget {
-  const _HomeWeatherPanel({this.embedded = false});
+  const _HomeWeatherPanel({this.embedded = false, this.onTap});
 
   final bool embedded;
+  final VoidCallback? onTap;
 
   @override
   State<_HomeWeatherPanel> createState() => _HomeWeatherPanelState();
@@ -4698,6 +4954,8 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
                 ? 'Taichung City'
                 : '${data!.locationName} / feels like ${data.apparentTempC.round()}°';
 
+        final gap = widget.embedded ? 10.0 : 18.0;
+        final tempSize = widget.embedded ? 38.0 : 46.0;
         final content = Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
@@ -4722,14 +4980,14 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
                 ),
               ],
             ),
-            const SizedBox(height: 18),
+            SizedBox(height: gap),
             Row(
               crossAxisAlignment: CrossAxisAlignment.end,
               children: [
                 Text(
                   tempLabel,
                   style: TextStyle(
-                    fontSize: 46,
+                    fontSize: tempSize,
                     height: 0.92,
                     fontWeight: FontWeight.w900,
                     color: textOnWeather,
@@ -4772,7 +5030,7 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
               ],
             ),
             if (forecast.isNotEmpty) ...[
-              const SizedBox(height: 18),
+              SizedBox(height: widget.embedded ? 12 : 18),
               Row(
                 children: [
                   for (int index = 0; index < forecast.length; index++) ...[
@@ -4791,10 +5049,17 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
             ],
           ],
         );
-        return _WeatherWidgetFrame(
+        final frame = _WeatherWidgetFrame(
           mood: mood,
           embedded: widget.embedded,
           child: content,
+        );
+        if (widget.onTap == null) return frame;
+        return OSTouchFeedback(
+          onTap: widget.onTap!,
+          borderRadius: BorderRadius.circular(widget.embedded ? 24 : 28),
+          minSize: Size(180, widget.embedded ? 166 : 220),
+          child: frame,
         );
       },
     );
@@ -4820,9 +5085,9 @@ class _WeatherWidgetFrame extends StatelessWidget {
     final radius = BorderRadius.circular(embedded ? 24 : 28);
 
     return ConstrainedBox(
-      constraints: BoxConstraints(minHeight: embedded ? 214 : 220),
+      constraints: BoxConstraints(minHeight: embedded ? 164 : 220),
       child: Container(
-        padding: const EdgeInsets.all(16),
+        padding: EdgeInsets.all(embedded ? 12 : 16),
         decoration: BoxDecoration(
           borderRadius: radius,
           gradient: LinearGradient(
@@ -5442,7 +5707,7 @@ class _AgendaEmptyState extends StatelessWidget {
     final dark = context.isDark;
     return Container(
       width: double.infinity,
-      padding: const EdgeInsets.all(14),
+      padding: const EdgeInsets.all(10),
       decoration: BoxDecoration(
         gradient: LinearGradient(
           colors: [
@@ -5654,7 +5919,7 @@ class _RailSection extends StatelessWidget {
         color: dark
             ? Colors.white.withValues(alpha: 0.035)
             : Colors.white.withValues(alpha: 0.48),
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(22),
         border: Border.all(
           color: dark
               ? Colors.white.withValues(alpha: 0.055)

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -38,10 +38,12 @@ class HomeSurface extends StatefulWidget {
 class _HomeSurfaceState extends State<HomeSurface> {
   static const String _wallpaperStyleBaseKey = 'os_home_wallpaper_style_v1';
   static const String _wallpaperImageBaseKey = 'os_home_wallpaper_image_v1';
+  static const String _readabilityBaseKey = 'os_home_readability_v1';
 
   final DashboardPreferencesService _preferences =
       const DashboardPreferencesService();
   _HomeWallpaperStyle _wallpaperStyle = _HomeWallpaperStyle.defaultStyle;
+  _HomeReadabilityPreset _readabilityPreset = _HomeReadabilityPreset.balanced;
   Uint8List? _wallpaperImageBytes;
   String? _wallpaperImageBase64;
   String? _loadedUserId;
@@ -75,9 +77,16 @@ class _HomeSurfaceState extends State<HomeSurface> {
           userId: userId,
         ),
       );
+      final readability = await _preferences.readScopedString(
+        scopedKey: _preferences.scopedKey(
+          baseKey: _readabilityBaseKey,
+          userId: userId,
+        ),
+      );
       if (!mounted || _loadedUserId != userId) return;
       setState(() {
         _wallpaperStyle = _HomeWallpaperStyleX.fromId(style);
+        _readabilityPreset = _HomeReadabilityPresetX.fromId(readability);
         _wallpaperImageBase64 = image;
         _wallpaperImageBytes = _decodeWallpaperImage(image);
         _loadingWallpaper = false;
@@ -133,6 +142,19 @@ class _HomeSurfaceState extends State<HomeSurface> {
     }
   }
 
+  Future<void> _saveReadabilityPreset(
+    _HomeReadabilityPreset preset,
+  ) async {
+    setState(() => _readabilityPreset = preset);
+    await _preferences.writeString(
+      key: _preferences.scopedKey(
+        baseKey: _readabilityBaseKey,
+        userId: _wallpaperUserId,
+      ),
+      value: preset.id,
+    );
+  }
+
   Future<void> _pickWallpaperImage() async {
     final picked = await FilePicker.platform.pickFiles(
       type: FileType.custom,
@@ -162,78 +184,109 @@ class _HomeSurfaceState extends State<HomeSurface> {
       showDragHandle: true,
       backgroundColor: Theme.of(context).colorScheme.surface,
       builder: (sheetContext) {
-        return SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(20, 4, 20, 22),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  'Home background',
-                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.w800,
-                      ),
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  'Choose a built-in wallpaper or add your own image. Dark mode stays available from the moon button.',
-                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                      ),
-                ),
-                const SizedBox(height: 18),
-                Wrap(
-                  spacing: 10,
-                  runSpacing: 10,
+        return StatefulBuilder(
+          builder: (context, setSheetState) {
+            return SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(20, 4, 20, 22),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    for (final style in _HomeWallpaperStyle.values)
-                      if (style != _HomeWallpaperStyle.customImage ||
-                          _wallpaperImageBytes != null)
-                        _WallpaperChoiceChip(
-                          label: style.label,
-                          selected: _wallpaperStyle == style,
-                          accent: style.accent,
-                          onTap: () {
-                            Navigator.of(sheetContext).pop();
-                            _saveWallpaper(style: style);
-                          },
-                        ),
-                  ],
-                ),
-                const SizedBox(height: 18),
-                Row(
-                  children: [
-                    Expanded(
-                      child: FilledButton.icon(
-                        onPressed: () {
-                          Navigator.of(sheetContext).pop();
-                          _pickWallpaperImage();
-                        },
-                        icon: const Icon(Icons.add_photo_alternate_outlined),
-                        label: Text(
-                          _wallpaperImageBytes == null
-                              ? 'Add image'
-                              : 'Change image',
-                        ),
-                      ),
+                    Text(
+                      'Home background',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.w800,
+                          ),
                     ),
-                    if (_wallpaperImageBytes != null) ...[
-                      const SizedBox(width: 10),
-                      OutlinedButton.icon(
-                        onPressed: () {
-                          Navigator.of(sheetContext).pop();
-                          _clearWallpaperImage();
-                        },
-                        icon: const Icon(Icons.wallpaper_outlined),
-                        label: const Text('Reset'),
-                      ),
-                    ],
+                    const SizedBox(height: 6),
+                    Text(
+                      'Choose a built-in wallpaper or add your own image. Dark mode stays available from the moon button.',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                    ),
+                    const SizedBox(height: 18),
+                    Wrap(
+                      spacing: 10,
+                      runSpacing: 10,
+                      children: [
+                        for (final style in _HomeWallpaperStyle.values)
+                          if (style != _HomeWallpaperStyle.customImage ||
+                              _wallpaperImageBytes != null)
+                            _WallpaperChoiceChip(
+                              label: style.label,
+                              selected: _wallpaperStyle == style,
+                              accent: style.accent,
+                              onTap: () {
+                                Navigator.of(sheetContext).pop();
+                                _saveWallpaper(style: style);
+                              },
+                            ),
+                      ],
+                    ),
+                    const SizedBox(height: 18),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: FilledButton.icon(
+                            onPressed: () {
+                              Navigator.of(sheetContext).pop();
+                              _pickWallpaperImage();
+                            },
+                            icon:
+                                const Icon(Icons.add_photo_alternate_outlined),
+                            label: Text(
+                              _wallpaperImageBytes == null
+                                  ? 'Add image'
+                                  : 'Change image',
+                            ),
+                          ),
+                        ),
+                        if (_wallpaperImageBytes != null) ...[
+                          const SizedBox(width: 10),
+                          OutlinedButton.icon(
+                            onPressed: () {
+                              Navigator.of(sheetContext).pop();
+                              _clearWallpaperImage();
+                            },
+                            icon: const Icon(Icons.wallpaper_outlined),
+                            label: const Text('Reset'),
+                          ),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 22),
+                    Text(
+                      'Readability',
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w800,
+                          ),
+                    ),
+                    const SizedBox(height: 10),
+                    Wrap(
+                      spacing: 10,
+                      runSpacing: 10,
+                      children: [
+                        for (final preset in _HomeReadabilityPreset.values)
+                          _ReadabilityPresetChip(
+                            preset: preset,
+                            selected: _readabilityPreset == preset,
+                            onTap: () {
+                              setSheetState(() {
+                                _readabilityPreset = preset;
+                              });
+                              _saveReadabilityPreset(preset);
+                            },
+                          ),
+                      ],
+                    ),
                   ],
                 ),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
         );
       },
     );
@@ -268,83 +321,88 @@ class _HomeSurfaceState extends State<HomeSurface> {
     final themeMode = context.watch<ThemeModeNotifier>().themeMode;
     final toggleTheme = context.read<ThemeModeNotifier>().toggleTheme;
 
-    return Scaffold(
-      backgroundColor: OSColors.bg(context.isDark),
-      body: SafeArea(
-        bottom: false,
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final isDesktop =
-                constraints.maxWidth >= 1220 && constraints.maxHeight >= 760;
-            final horizontalPadding = constraints.maxWidth < 760 ? 14.0 : 20.0;
-            final contentPadding = EdgeInsets.fromLTRB(
-              horizontalPadding,
-              10,
-              horizontalPadding,
-              24,
-            );
+    return _HomeReadabilityScope(
+      preset: _readabilityPreset,
+      child: Scaffold(
+        backgroundColor: OSColors.bg(context.isDark),
+        body: SafeArea(
+          bottom: false,
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              final isDesktop =
+                  constraints.maxWidth >= 1220 && constraints.maxHeight >= 760;
+              final horizontalPadding =
+                  constraints.maxWidth < 760 ? 14.0 : 20.0;
+              final contentPadding = EdgeInsets.fromLTRB(
+                horizontalPadding,
+                10,
+                horizontalPadding,
+                24,
+              );
 
-            return Stack(
-              children: [
-                Positioned.fill(
-                  child: _HomeBackdrop(
-                    style: _wallpaperStyle,
-                    imageBytes: _wallpaperImageBytes,
+              return Stack(
+                children: [
+                  Positioned.fill(
+                    child: _HomeBackdrop(
+                      style: _wallpaperStyle,
+                      imageBytes: _wallpaperImageBytes,
+                      readability: _readabilityPreset,
+                    ),
                   ),
-                ),
-                if (_loadingWallpaper)
-                  const Positioned(
-                    width: 0,
-                    height: 0,
-                    child: SizedBox.shrink(),
+                  if (_loadingWallpaper)
+                    const Positioned(
+                      width: 0,
+                      height: 0,
+                      child: SizedBox.shrink(),
+                    ),
+                  Positioned.fill(
+                    child: isDesktop
+                        ? Padding(
+                            padding: contentPadding,
+                            child: _HomeDesktopLayout(
+                              teacherName: teacherName,
+                              schoolName: schoolName,
+                              primaryClass: primaryClass,
+                              classes: classes,
+                              reminders: reminders,
+                              primaryReminder: primaryReminder,
+                              totalStudents: totalStudents,
+                              unread: unread,
+                              now: now,
+                              themeMode: themeMode,
+                              onShadeTap: controller.openShade,
+                              onAssistantTap: controller.openAssistant,
+                              onLauncherTap: controller.openLauncher,
+                              onThemeTap: toggleTheme,
+                              onWallpaperTap: _showWallpaperSheet,
+                            ),
+                          )
+                        : SingleChildScrollView(
+                            padding: contentPadding,
+                            child: _HomeStackedLayout(
+                              width: constraints.maxWidth,
+                              teacherName: teacherName,
+                              schoolName: schoolName,
+                              primaryClass: primaryClass,
+                              classes: classes,
+                              reminders: reminders,
+                              primaryReminder: primaryReminder,
+                              totalStudents: totalStudents,
+                              unread: unread,
+                              now: now,
+                              themeMode: themeMode,
+                              onShadeTap: controller.openShade,
+                              onAssistantTap: controller.openAssistant,
+                              onLauncherTap: controller.openLauncher,
+                              onThemeTap: toggleTheme,
+                              onWallpaperTap: _showWallpaperSheet,
+                            ),
+                          ),
                   ),
-                Positioned.fill(
-                  child: isDesktop
-                      ? Padding(
-                          padding: contentPadding,
-                          child: _HomeDesktopLayout(
-                            teacherName: teacherName,
-                            schoolName: schoolName,
-                            primaryClass: primaryClass,
-                            classes: classes,
-                            reminders: reminders,
-                            primaryReminder: primaryReminder,
-                            totalStudents: totalStudents,
-                            unread: unread,
-                            now: now,
-                            themeMode: themeMode,
-                            onShadeTap: controller.openShade,
-                            onAssistantTap: controller.openAssistant,
-                            onLauncherTap: controller.openLauncher,
-                            onThemeTap: toggleTheme,
-                            onWallpaperTap: _showWallpaperSheet,
-                          ),
-                        )
-                      : SingleChildScrollView(
-                          padding: contentPadding,
-                          child: _HomeStackedLayout(
-                            width: constraints.maxWidth,
-                            teacherName: teacherName,
-                            schoolName: schoolName,
-                            primaryClass: primaryClass,
-                            classes: classes,
-                            reminders: reminders,
-                            primaryReminder: primaryReminder,
-                            totalStudents: totalStudents,
-                            unread: unread,
-                            now: now,
-                            themeMode: themeMode,
-                            onShadeTap: controller.openShade,
-                            onAssistantTap: controller.openAssistant,
-                            onLauncherTap: controller.openLauncher,
-                            onThemeTap: toggleTheme,
-                            onWallpaperTap: _showWallpaperSheet,
-                          ),
-                        ),
-                ),
-              ],
-            );
-          },
+                ],
+              );
+            },
+          ),
         ),
       ),
     );
@@ -3757,6 +3815,159 @@ extension _HomeWallpaperStyleX on _HomeWallpaperStyle {
   }
 }
 
+enum _HomeReadabilityPreset {
+  clear,
+  balanced,
+  focus,
+  highContrast,
+}
+
+extension _HomeReadabilityPresetX on _HomeReadabilityPreset {
+  String get id {
+    switch (this) {
+      case _HomeReadabilityPreset.clear:
+        return 'clear';
+      case _HomeReadabilityPreset.balanced:
+        return 'balanced';
+      case _HomeReadabilityPreset.focus:
+        return 'focus';
+      case _HomeReadabilityPreset.highContrast:
+        return 'high_contrast';
+    }
+  }
+
+  String get label {
+    switch (this) {
+      case _HomeReadabilityPreset.clear:
+        return 'Clear';
+      case _HomeReadabilityPreset.balanced:
+        return 'Balanced';
+      case _HomeReadabilityPreset.focus:
+        return 'Focus';
+      case _HomeReadabilityPreset.highContrast:
+        return 'High Contrast';
+    }
+  }
+
+  IconData get icon {
+    switch (this) {
+      case _HomeReadabilityPreset.clear:
+        return Icons.visibility_outlined;
+      case _HomeReadabilityPreset.balanced:
+        return Icons.tonality_outlined;
+      case _HomeReadabilityPreset.focus:
+        return Icons.center_focus_strong_outlined;
+      case _HomeReadabilityPreset.highContrast:
+        return Icons.contrast_rounded;
+    }
+  }
+
+  double wallpaperScrimAlpha(bool dark, bool hasImage) {
+    if (hasImage) {
+      switch (this) {
+        case _HomeReadabilityPreset.clear:
+          return dark ? 0.26 : 0.12;
+        case _HomeReadabilityPreset.balanced:
+          return dark ? 0.42 : 0.28;
+        case _HomeReadabilityPreset.focus:
+          return dark ? 0.56 : 0.40;
+        case _HomeReadabilityPreset.highContrast:
+          return dark ? 0.70 : 0.56;
+      }
+    }
+
+    switch (this) {
+      case _HomeReadabilityPreset.clear:
+        return dark ? 0.00 : 0.00;
+      case _HomeReadabilityPreset.balanced:
+        return dark ? 0.03 : 0.02;
+      case _HomeReadabilityPreset.focus:
+        return dark ? 0.09 : 0.06;
+      case _HomeReadabilityPreset.highContrast:
+        return dark ? 0.16 : 0.12;
+    }
+  }
+
+  double get wallpaperBlurSigma {
+    switch (this) {
+      case _HomeReadabilityPreset.clear:
+        return 0;
+      case _HomeReadabilityPreset.balanced:
+        return 0;
+      case _HomeReadabilityPreset.focus:
+        return 1.2;
+      case _HomeReadabilityPreset.highContrast:
+        return 2.0;
+    }
+  }
+
+  double get glassBlend {
+    switch (this) {
+      case _HomeReadabilityPreset.clear:
+        return 0;
+      case _HomeReadabilityPreset.balanced:
+        return 0.02;
+      case _HomeReadabilityPreset.focus:
+        return 0.12;
+      case _HomeReadabilityPreset.highContrast:
+        return 0.24;
+    }
+  }
+
+  double get blurMultiplier {
+    switch (this) {
+      case _HomeReadabilityPreset.clear:
+        return 0.86;
+      case _HomeReadabilityPreset.balanced:
+        return 1.0;
+      case _HomeReadabilityPreset.focus:
+        return 1.14;
+      case _HomeReadabilityPreset.highContrast:
+        return 1.28;
+    }
+  }
+
+  double get borderBoost {
+    switch (this) {
+      case _HomeReadabilityPreset.clear:
+        return 0;
+      case _HomeReadabilityPreset.balanced:
+        return 0.02;
+      case _HomeReadabilityPreset.focus:
+        return 0.08;
+      case _HomeReadabilityPreset.highContrast:
+        return 0.15;
+    }
+  }
+
+  static _HomeReadabilityPreset fromId(String? id) {
+    for (final preset in _HomeReadabilityPreset.values) {
+      if (preset.id == id) return preset;
+    }
+    return _HomeReadabilityPreset.balanced;
+  }
+}
+
+class _HomeReadabilityScope extends InheritedWidget {
+  const _HomeReadabilityScope({
+    required this.preset,
+    required super.child,
+  });
+
+  final _HomeReadabilityPreset preset;
+
+  static _HomeReadabilityPreset of(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<_HomeReadabilityScope>();
+    return scope?.preset ?? _HomeReadabilityPreset.balanced;
+  }
+
+  @override
+  bool updateShouldNotify(covariant _HomeReadabilityScope oldWidget) {
+    return oldWidget.preset != preset;
+  }
+}
+
 class _WallpaperChoiceChip extends StatelessWidget {
   const _WallpaperChoiceChip({
     required this.label,
@@ -3794,14 +4005,58 @@ class _WallpaperChoiceChip extends StatelessWidget {
   }
 }
 
+class _ReadabilityPresetChip extends StatelessWidget {
+  const _ReadabilityPresetChip({
+    required this.preset,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final _HomeReadabilityPreset preset;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = switch (preset) {
+      _HomeReadabilityPreset.clear => OSColors.cyan,
+      _HomeReadabilityPreset.balanced => OSColors.blue,
+      _HomeReadabilityPreset.focus => OSColors.indigo,
+      _HomeReadabilityPreset.highContrast => OSColors.amber,
+    };
+
+    return ChoiceChip(
+      label: Text(preset.label),
+      selected: selected,
+      onSelected: (_) => onTap(),
+      avatar: Icon(
+        selected ? Icons.check_rounded : preset.icon,
+        size: 17,
+        color: selected ? Colors.white : accent,
+      ),
+      selectedColor: accent,
+      labelStyle: TextStyle(
+        color:
+            selected ? Colors.white : Theme.of(context).colorScheme.onSurface,
+        fontWeight: FontWeight.w800,
+      ),
+      side: BorderSide(
+        color: selected ? accent : Theme.of(context).colorScheme.outlineVariant,
+      ),
+    );
+  }
+}
+
 class _HomeBackdrop extends StatelessWidget {
   const _HomeBackdrop({
     required this.style,
     required this.imageBytes,
+    required this.readability,
   });
 
   final _HomeWallpaperStyle style;
   final Uint8List? imageBytes;
+  final _HomeReadabilityPreset readability;
 
   @override
   Widget build(BuildContext context) {
@@ -3825,19 +4080,41 @@ class _HomeBackdrop extends StatelessWidget {
         ),
         if (useImage)
           Positioned.fill(
-            child: Image.memory(
-              imageBytes!,
-              fit: BoxFit.cover,
-              filterQuality: FilterQuality.high,
+            child: ImageFiltered(
+              imageFilter: ui.ImageFilter.blur(
+                sigmaX: readability.wallpaperBlurSigma,
+                sigmaY: readability.wallpaperBlurSigma,
+              ),
+              child: Image.memory(
+                imageBytes!,
+                fit: BoxFit.cover,
+                filterQuality: FilterQuality.high,
+              ),
             ),
           ),
-        if (useImage)
+        Positioned.fill(
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: (dark ? Colors.black : Colors.white).withValues(
+                alpha: readability.wallpaperScrimAlpha(dark, useImage),
+              ),
+            ),
+          ),
+        ),
+        if (useImage && readability != _HomeReadabilityPreset.clear)
           Positioned.fill(
             child: DecoratedBox(
               decoration: BoxDecoration(
-                color: dark
-                    ? Colors.black.withValues(alpha: 0.42)
-                    : Colors.white.withValues(alpha: 0.28),
+                gradient: RadialGradient(
+                  center: const Alignment(-0.28, -0.74),
+                  radius: 1.05,
+                  colors: [
+                    (dark ? OSColors.blue : Colors.white).withValues(
+                      alpha: dark ? 0.12 : 0.24,
+                    ),
+                    Colors.transparent,
+                  ],
+                ),
               ),
             ),
           ),
@@ -6206,18 +6483,28 @@ class _RailSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
+    final readability = _HomeReadabilityScope.of(context);
+    final solidColor = dark
+        ? const Color(0xFF111A27).withValues(alpha: 0.64)
+        : Colors.white.withValues(alpha: 0.92);
+    final baseFill = dark
+        ? Colors.white.withValues(alpha: 0.035)
+        : Colors.white.withValues(alpha: 0.48);
+    final borderFill = dark
+        ? Colors.white.withValues(alpha: 0.055)
+        : Colors.white.withValues(alpha: 0.58);
 
     final section = Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: dark
-            ? Colors.white.withValues(alpha: 0.035)
-            : Colors.white.withValues(alpha: 0.48),
+        color: Color.lerp(baseFill, solidColor, readability.glassBlend),
         borderRadius: BorderRadius.circular(22),
         border: Border.all(
-          color: dark
-              ? Colors.white.withValues(alpha: 0.055)
-              : Colors.white.withValues(alpha: 0.58),
+          color: Color.lerp(
+            borderFill,
+            dark ? Colors.white : OSColors.blue,
+            readability.borderBoost,
+          )!,
         ),
       ),
       child: child,
@@ -6245,6 +6532,7 @@ class _GlassPanel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
+    final readability = _HomeReadabilityScope.of(context);
     final (baseColor, secondaryColor, borderColor, shadowEmphasis, blurSigma) =
         switch (tone) {
       _HomePanelTone.stage => (
@@ -6300,21 +6588,34 @@ class _GlassPanel extends StatelessWidget {
           WorkspaceChrome.panelBlur * 0.92,
         ),
     };
+    final solidColor = dark
+        ? const Color(0xFF111A27).withValues(alpha: 0.72)
+        : Colors.white.withValues(alpha: 0.96);
+    final readableBaseColor =
+        Color.lerp(baseColor, solidColor, readability.glassBlend)!;
+    final readableSecondaryColor =
+        Color.lerp(secondaryColor, solidColor, readability.glassBlend)!;
+    final readableBorderColor = Color.lerp(
+      borderColor,
+      dark ? Colors.white : OSColors.blue,
+      readability.borderBoost,
+    )!;
+    final readableBlurSigma = blurSigma * readability.blurMultiplier;
 
     return ClipRRect(
       borderRadius: BorderRadius.circular(radius),
       child: BackdropFilter(
         filter: ui.ImageFilter.blur(
-          sigmaX: blurSigma,
-          sigmaY: blurSigma,
+          sigmaX: readableBlurSigma,
+          sigmaY: readableBlurSigma,
         ),
         child: Container(
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(radius),
-            border: Border.all(color: borderColor),
+            border: Border.all(color: readableBorderColor),
             boxShadow: WorkspaceChrome.panelShadow(
               context,
-              emphasis: shadowEmphasis,
+              emphasis: shadowEmphasis + readability.borderBoost,
             ),
           ),
           child: Stack(
@@ -6328,9 +6629,9 @@ class _GlassPanel extends StatelessWidget {
                           begin: Alignment.topLeft,
                           end: Alignment.bottomRight,
                           colors: [
-                            baseColor,
-                            secondaryColor,
-                            baseColor,
+                            readableBaseColor,
+                            readableSecondaryColor,
+                            readableBaseColor,
                           ],
                         ),
                   ),

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -422,13 +422,24 @@ class _HomeDesktopLayout extends StatefulWidget {
 }
 
 class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
-  static const String _folderTapRegionGroup = 'home-folder-workspace-desktop';
-  _HomeWorkspaceFolder? _selectedFolder;
+  static const String _miniAppTapRegionGroup = 'home-mini-app-desktop';
+  _HomeMiniApp? _selectedMiniApp;
 
-  void _closeSelectedFolder() {
-    if (_selectedFolder != null) {
-      setState(() => _selectedFolder = null);
+  void _closeMiniApp() {
+    if (_selectedMiniApp != null) {
+      setState(() => _selectedMiniApp = null);
     }
+  }
+
+  void _openMiniApp(_HomeMiniApp app) {
+    setState(() => _selectedMiniApp = app);
+  }
+
+  void _toggleFolder(_HomeWorkspaceFolder folder) {
+    final app = _miniAppForFolder(folder);
+    setState(() {
+      _selectedMiniApp = _selectedMiniApp == app ? null : app;
+    });
   }
 
   @override
@@ -459,6 +470,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                 child: _HomeShortcutShelf(
                   unread: widget.unread,
                   onLauncherTap: widget.onLauncherTap,
+                  onMessagesTap: () => _openMiniApp(_HomeMiniApp.messages),
                   compact: true,
                 ),
               ),
@@ -491,24 +503,20 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                       reminderCount: widget.reminders.length,
                       now: widget.now,
                       compact: false,
+                      onMessagesTap: () => _openMiniApp(_HomeMiniApp.messages),
+                      onPlannerTap: () => _openMiniApp(_HomeMiniApp.agenda),
+                      onClassesTap: () => _openMiniApp(_HomeMiniApp.classes),
                     ),
                   ),
                   const SizedBox(height: 14),
-                  TapRegion(
-                    groupId: _folderTapRegionGroup,
-                    onTapOutside: (_) => _closeSelectedFolder(),
-                    child: Align(
-                      alignment: Alignment.center,
-                      child: _HomeWorkspaceFolderStrip(
-                        selected: _selectedFolder,
-                        classCount: widget.classes.length,
-                        reminderCount: widget.reminders.length,
-                        unread: widget.unread,
-                        onSelected: (folder) => setState(() {
-                          _selectedFolder =
-                              _selectedFolder == folder ? null : folder;
-                        }),
-                      ),
+                  Align(
+                    alignment: Alignment.center,
+                    child: _HomeWorkspaceFolderStrip(
+                      selected: _folderForMiniApp(_selectedMiniApp),
+                      classCount: widget.classes.length,
+                      reminderCount: widget.reminders.length,
+                      unread: widget.unread,
+                      onSelected: _toggleFolder,
                     ),
                   ),
                   const SizedBox(height: 14),
@@ -521,22 +529,23 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                         switchInCurve: Curves.easeOutCubic,
                         switchOutCurve: Curves.easeInOut,
                         transitionBuilder: _homeFolderTransition,
-                        child: _selectedFolder == null
+                        child: _selectedMiniApp == null
                             ? const _HomeCalmWorkspaceFloor(
                                 key: ValueKey('workspace-closed'),
                               )
                             : TapRegion(
-                                groupId: _folderTapRegionGroup,
-                                onTapOutside: (_) => _closeSelectedFolder(),
-                                child: _HomeWorkspaceFolderPanel(
-                                  key: ValueKey(_selectedFolder),
-                                  folder: _selectedFolder!,
+                                groupId: _miniAppTapRegionGroup,
+                                onTapOutside: (_) => _closeMiniApp(),
+                                child: _HomeMiniAppWindow(
+                                  key: ValueKey(_selectedMiniApp),
+                                  app: _selectedMiniApp!,
                                   primaryClass: widget.primaryClass,
                                   classes: widget.classes,
                                   reminders: widget.reminders,
                                   unread: widget.unread,
                                   totalStudents: widget.totalStudents,
                                   now: widget.now,
+                                  onClose: _closeMiniApp,
                                 ),
                               ),
                       ),
@@ -555,7 +564,9 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
             unread: widget.unread,
             reminders: widget.reminders,
             reminderCount: widget.reminders.length,
-            onAudioTap: () => context.go(AppRoutes.dashboard),
+            onAudioTap: () => _openMiniApp(_HomeMiniApp.audio),
+            onMessagesTap: () => _openMiniApp(_HomeMiniApp.messages),
+            onAgendaTap: () => _openMiniApp(_HomeMiniApp.agenda),
           ),
         ),
       ],
@@ -563,60 +574,60 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
   }
 }
 
-enum _HomeLivePanel { messages, agenda, audio }
+enum _HomeMiniApp {
+  today,
+  classes,
+  tasks,
+  messages,
+  insights,
+  agenda,
+  audio,
+}
 
-class _HomeUtilityRail extends StatefulWidget {
+_HomeMiniApp _miniAppForFolder(_HomeWorkspaceFolder folder) {
+  return switch (folder) {
+    _HomeWorkspaceFolder.today => _HomeMiniApp.today,
+    _HomeWorkspaceFolder.classes => _HomeMiniApp.classes,
+    _HomeWorkspaceFolder.tasks => _HomeMiniApp.tasks,
+    _HomeWorkspaceFolder.messages => _HomeMiniApp.messages,
+    _HomeWorkspaceFolder.insights => _HomeMiniApp.insights,
+  };
+}
+
+_HomeWorkspaceFolder? _folderForMiniApp(_HomeMiniApp? app) {
+  return switch (app) {
+    _HomeMiniApp.today => _HomeWorkspaceFolder.today,
+    _HomeMiniApp.classes => _HomeWorkspaceFolder.classes,
+    _HomeMiniApp.tasks => _HomeWorkspaceFolder.tasks,
+    _HomeMiniApp.messages => _HomeWorkspaceFolder.messages,
+    _HomeMiniApp.insights => _HomeWorkspaceFolder.insights,
+    _HomeMiniApp.agenda || _HomeMiniApp.audio || null => null,
+  };
+}
+
+class _HomeUtilityRail extends StatelessWidget {
   const _HomeUtilityRail({
     required this.unread,
     required this.reminders,
     required this.reminderCount,
     required this.onAudioTap,
+    required this.onMessagesTap,
+    required this.onAgendaTap,
   });
 
   final int unread;
   final List<TeacherWorkspaceReminderSnapshot> reminders;
   final int reminderCount;
   final VoidCallback onAudioTap;
-
-  @override
-  State<_HomeUtilityRail> createState() => _HomeUtilityRailState();
-}
-
-class _HomeUtilityRailState extends State<_HomeUtilityRail> {
-  late _HomeLivePanel _selected = _defaultLivePanel();
-
-  _HomeLivePanel _defaultLivePanel() {
-    if (widget.unread > 0) return _HomeLivePanel.messages;
-    if (widget.reminderCount > 0) return _HomeLivePanel.agenda;
-    return _HomeLivePanel.audio;
-  }
-
-  @override
-  void didUpdateWidget(covariant _HomeUtilityRail oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.unread == widget.unread &&
-        oldWidget.reminderCount == widget.reminderCount) {
-      return;
-    }
-    final nextDefault = _defaultLivePanel();
-    final oldDefault = oldWidget.unread > 0
-        ? _HomeLivePanel.messages
-        : oldWidget.reminderCount > 0
-            ? _HomeLivePanel.agenda
-            : _HomeLivePanel.audio;
-    if (_selected == oldDefault) {
-      _selected = nextDefault;
-    }
-  }
+  final VoidCallback onMessagesTap;
+  final VoidCallback onAgendaTap;
 
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
     final signalText = [
-      widget.unread == 0 ? 'Inbox quiet' : '${widget.unread} unread',
-      widget.reminderCount == 0
-          ? 'agenda clear'
-          : '${widget.reminderCount} queued',
+      unread == 0 ? 'Inbox quiet' : '$unread unread',
+      reminderCount == 0 ? 'agenda clear' : '$reminderCount queued',
     ].join(' / ');
 
     return _GlassPanel(
@@ -671,107 +682,27 @@ class _HomeUtilityRailState extends State<_HomeUtilityRail> {
           ),
           const SizedBox(height: 14),
           const _HomeWeatherPanel(embedded: true),
-          const SizedBox(height: 12),
-          _HomeLiveStack(
-            selected: _selected,
-            unread: widget.unread,
-            reminders: widget.reminders,
-            onAudioTap: widget.onAudioTap,
-            onSelected: (panel) => setState(() => _selected = panel),
+          const SizedBox(height: 10),
+          _HomeAudioPanel(
+            embedded: true,
+            compact: true,
+            onTap: onAudioTap,
           ),
-        ],
-      ),
-    );
-  }
-}
-
-class _HomeLiveStack extends StatelessWidget {
-  const _HomeLiveStack({
-    required this.selected,
-    required this.unread,
-    required this.reminders,
-    required this.onAudioTap,
-    required this.onSelected,
-  });
-
-  final _HomeLivePanel selected;
-  final int unread;
-  final List<TeacherWorkspaceReminderSnapshot> reminders;
-  final VoidCallback onAudioTap;
-  final ValueChanged<_HomeLivePanel> onSelected;
-
-  @override
-  Widget build(BuildContext context) {
-    final dark = context.isDark;
-    return _RailSection(
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          Container(
-            padding: const EdgeInsets.all(3),
-            decoration: BoxDecoration(
-              color: dark
-                  ? Colors.white.withValues(alpha: 0.035)
-                  : Colors.white.withValues(alpha: 0.52),
-              borderRadius: OSRadius.pillBr,
-              border: Border.all(
-                color: dark
-                    ? Colors.white.withValues(alpha: 0.045)
-                    : Colors.white.withValues(alpha: 0.64),
-              ),
-            ),
-            child: Row(
-              children: [
-                _LiveStackTab(
-                  label: 'Messages',
-                  icon: Icons.forum_rounded,
-                  selected: selected == _HomeLivePanel.messages,
-                  accent: OSColors.cyan,
-                  badge: unread > 0 ? '$unread' : null,
-                  onTap: () => onSelected(_HomeLivePanel.messages),
-                ),
-                _LiveStackTab(
-                  label: 'Agenda',
-                  icon: Icons.event_available_rounded,
-                  selected: selected == _HomeLivePanel.agenda,
-                  accent: OSColors.amber,
-                  onTap: () => onSelected(_HomeLivePanel.agenda),
-                ),
-                _LiveStackTab(
-                  label: 'Audio',
-                  icon: Icons.graphic_eq_rounded,
-                  selected: selected == _HomeLivePanel.audio,
-                  accent: OSColors.indigo,
-                  onTap: () => onSelected(_HomeLivePanel.audio),
-                ),
-              ],
+          const SizedBox(height: 10),
+          _RailSection(
+            child: _HomeMessagesWidget(
+              unread: unread,
+              onTap: onMessagesTap,
+              compact: true,
             ),
           ),
-          const SizedBox(height: 12),
-          AnimatedSwitcher(
-            duration: const Duration(milliseconds: 240),
-            switchInCurve: Curves.easeOutCubic,
-            switchOutCurve: Curves.easeInOut,
-            transitionBuilder: _homeFolderTransition,
-            child: switch (selected) {
-              _HomeLivePanel.messages => _HomeMessagesWidget(
-                  key: const ValueKey('live-messages'),
-                  unread: unread,
-                ),
-              _HomeLivePanel.agenda => _HomeAgendaPanel(
-                  key: const ValueKey('live-agenda'),
-                  reminders: reminders,
-                  scrollable: false,
-                  embedded: false,
-                  framed: false,
-                ),
-              _HomeLivePanel.audio => _HomeAudioPanel(
-                  key: const ValueKey('live-audio'),
-                  embedded: false,
-                  framed: false,
-                  onTap: onAudioTap,
-                ),
-            },
+          const SizedBox(height: 10),
+          _HomeAgendaPanel(
+            reminders: reminders,
+            scrollable: false,
+            embedded: true,
+            compact: true,
+            onTap: onAgendaTap,
           ),
         ],
       ),
@@ -781,11 +712,14 @@ class _HomeLiveStack extends StatelessWidget {
 
 class _HomeMessagesWidget extends StatelessWidget {
   const _HomeMessagesWidget({
-    super.key,
     required this.unread,
+    required this.onTap,
+    this.compact = false,
   });
 
   final int unread;
+  final VoidCallback onTap;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
@@ -794,102 +728,112 @@ class _HomeMessagesWidget extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Container(
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
-                OSColors.cyan.withValues(alpha: dark ? 0.18 : 0.13),
-                OSColors.blue.withValues(alpha: dark ? 0.08 : 0.07),
-              ],
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
+        OSTouchFeedback(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(22),
+          minSize: Size(180, compact ? 74 : 92),
+          child: Container(
+            padding: EdgeInsets.all(compact ? 10 : 12),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [
+                  OSColors.cyan.withValues(alpha: dark ? 0.18 : 0.13),
+                  OSColors.blue.withValues(alpha: dark ? 0.08 : 0.07),
+                ],
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
+              borderRadius: BorderRadius.circular(22),
+              border: Border.all(
+                color: OSColors.cyan.withValues(alpha: hasUnread ? 0.28 : 0.14),
+              ),
             ),
-            borderRadius: BorderRadius.circular(22),
-            border: Border.all(
-              color: OSColors.cyan.withValues(alpha: hasUnread ? 0.28 : 0.14),
-            ),
-          ),
-          child: Row(
-            children: [
-              Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  Container(
-                    width: 38,
-                    height: 38,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color:
-                          OSColors.cyan.withValues(alpha: dark ? 0.18 : 0.13),
-                      border: Border.all(
-                        color: OSColors.cyan.withValues(alpha: 0.24),
+            child: Row(
+              children: [
+                Stack(
+                  clipBehavior: Clip.none,
+                  children: [
+                    Container(
+                      width: compact ? 34 : 38,
+                      height: compact ? 34 : 38,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color:
+                            OSColors.cyan.withValues(alpha: dark ? 0.18 : 0.13),
+                        border: Border.all(
+                          color: OSColors.cyan.withValues(alpha: 0.24),
+                        ),
+                      ),
+                      child: const Icon(
+                        Icons.chat_bubble_outline_rounded,
+                        size: 19,
+                        color: OSColors.cyan,
                       ),
                     ),
-                    child: const Icon(
-                      Icons.chat_bubble_outline_rounded,
-                      size: 19,
-                      color: OSColors.cyan,
-                    ),
-                  ),
-                  if (hasUnread)
-                    Positioned(
-                      right: -1,
-                      top: -1,
-                      child: Container(
-                        width: 10,
-                        height: 10,
-                        decoration: BoxDecoration(
-                          color: OSColors.urgent,
-                          shape: BoxShape.circle,
-                          border: Border.all(
-                            color:
-                                dark ? const Color(0xFF0F172A) : Colors.white,
-                            width: 1.5,
+                    if (hasUnread)
+                      Positioned(
+                        right: -1,
+                        top: -1,
+                        child: Container(
+                          width: 10,
+                          height: 10,
+                          decoration: BoxDecoration(
+                            color: OSColors.urgent,
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color:
+                                  dark ? const Color(0xFF0F172A) : Colors.white,
+                              width: 1.5,
+                            ),
                           ),
                         ),
                       ),
-                    ),
-                ],
-              ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const _PanelEyebrow(label: 'Messages'),
-                    const SizedBox(height: 3),
-                    Text(
-                      hasUnread
-                          ? '$unread unread update${unread == 1 ? '' : 's'}'
-                          : 'Inbox quiet',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.w900,
-                        color: OSColors.text(dark),
-                      ),
-                    ),
-                    const SizedBox(height: 3),
-                    Text(
-                      hasUnread
-                          ? 'Review conversations before the next handoff.'
-                          : 'Class and staff threads are standing by.',
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontSize: 11.5,
-                        color: OSColors.textSecondary(dark),
-                      ),
-                    ),
                   ],
                 ),
-              ),
-            ],
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const _PanelEyebrow(label: 'Messages'),
+                      const SizedBox(height: 3),
+                      Text(
+                        hasUnread
+                            ? '$unread unread update${unread == 1 ? '' : 's'}'
+                            : 'Inbox quiet',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: compact ? 14 : 16,
+                          fontWeight: FontWeight.w900,
+                          color: OSColors.text(dark),
+                        ),
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        hasUnread
+                            ? 'Review conversations before handoff.'
+                            : 'Threads are standing by.',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 11.5,
+                          color: OSColors.textSecondary(dark),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Icon(
+                  Icons.open_in_new_rounded,
+                  size: 15,
+                  color: OSColors.textMuted(dark),
+                ),
+              ],
+            ),
           ),
         ),
-        const SizedBox(height: 12),
+        SizedBox(height: compact ? 8 : 12),
         _FolderMessagePreview(
           sender: unread == 0 ? 'Staff room' : 'Unread channels',
           snippet: unread == 0
@@ -898,106 +842,19 @@ class _HomeMessagesWidget extends StatelessWidget {
           status: unread == 0 ? 'quiet' : 'now',
           unread: unread > 0,
           accent: OSColors.cyan,
-          onTap: () => context.go(AppRoutes.communication),
+          onTap: onTap,
         ),
-        const SizedBox(height: 8),
-        _FolderMessagePreview(
-          sender: 'Class channels',
-          snippet: 'Families, students, and staff threads.',
-          status: 'live',
-          accent: OSColors.blue,
-          onTap: () => context.go(AppRoutes.communication),
-        ),
+        if (!compact) ...[
+          const SizedBox(height: 8),
+          _FolderMessagePreview(
+            sender: 'Class channels',
+            snippet: 'Families, students, and staff threads.',
+            status: 'live',
+            accent: OSColors.blue,
+            onTap: onTap,
+          ),
+        ],
       ],
-    );
-  }
-}
-
-class _LiveStackTab extends StatelessWidget {
-  const _LiveStackTab({
-    required this.label,
-    required this.icon,
-    required this.selected,
-    required this.accent,
-    required this.onTap,
-    this.badge,
-  });
-
-  final String label;
-  final IconData icon;
-  final bool selected;
-  final Color accent;
-  final VoidCallback onTap;
-  final String? badge;
-
-  @override
-  Widget build(BuildContext context) {
-    final dark = context.isDark;
-    return Expanded(
-      child: OSTouchFeedback(
-        onTap: onTap,
-        borderRadius: OSRadius.pillBr,
-        minSize: const Size(64, 34),
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 180),
-          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 8),
-          decoration: BoxDecoration(
-            color: selected
-                ? accent.withValues(alpha: dark ? 0.18 : 0.12)
-                : Colors.transparent,
-            borderRadius: OSRadius.pillBr,
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Stack(
-                clipBehavior: Clip.none,
-                children: [
-                  Icon(
-                    icon,
-                    size: 14,
-                    color: selected ? accent : OSColors.textMuted(dark),
-                  ),
-                  if (badge != null)
-                    Positioned(
-                      right: -5,
-                      top: -5,
-                      child: Container(
-                        width: 8,
-                        height: 8,
-                        decoration: BoxDecoration(
-                          color: OSColors.urgent,
-                          shape: BoxShape.circle,
-                          border: Border.all(
-                            color: dark
-                                ? const Color(0xFF172033)
-                                : Colors.white.withValues(alpha: 0.9),
-                            width: 1.2,
-                          ),
-                        ),
-                      ),
-                    ),
-                ],
-              ),
-              const SizedBox(width: 4),
-              Flexible(
-                child: Text(
-                  label,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: 10.5,
-                    fontWeight: FontWeight.w900,
-                    color: selected
-                        ? OSColors.text(dark)
-                        : OSColors.textMuted(dark),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
     );
   }
 }
@@ -1692,54 +1549,120 @@ class _HomeCalmWorkspaceFloor extends StatelessWidget {
   }
 }
 
-class _HomeWorkspaceFolderPanel extends StatelessWidget {
-  const _HomeWorkspaceFolderPanel({
+class _HomeMiniAppWindow extends StatelessWidget {
+  const _HomeMiniAppWindow({
     super.key,
-    required this.folder,
+    required this.app,
     required this.primaryClass,
     required this.classes,
     required this.reminders,
     required this.unread,
     required this.totalStudents,
     required this.now,
+    required this.onClose,
   });
 
-  final _HomeWorkspaceFolder folder;
+  final _HomeMiniApp app;
   final Class? primaryClass;
   final List<Class> classes;
   final List<TeacherWorkspaceReminderSnapshot> reminders;
   final int unread;
   final int totalStudents;
   final DateTime now;
+  final VoidCallback onClose;
 
   @override
   Widget build(BuildContext context) {
+    final dark = context.isDark;
+    final accent = _miniAppAccent(app);
     return _GlassPanel(
       tone: _HomePanelTone.whisper,
-      radius: 26,
-      padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+      radius: 28,
+      padding: const EdgeInsets.fromLTRB(14, 12, 14, 14),
       child: ConstrainedBox(
-        constraints: const BoxConstraints(minHeight: 176, maxHeight: 276),
-        child: SingleChildScrollView(child: _buildFolderContent(context)),
+        constraints: const BoxConstraints(minHeight: 286, maxHeight: 520),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                Container(
+                  width: 34,
+                  height: 34,
+                  decoration: BoxDecoration(
+                    color: accent.withValues(alpha: dark ? 0.16 : 0.11),
+                    borderRadius: BorderRadius.circular(13),
+                    border: Border.all(color: accent.withValues(alpha: 0.22)),
+                  ),
+                  child: Icon(_miniAppIcon(app), size: 18, color: accent),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const _PanelEyebrow(label: 'Mini Desktop'),
+                      const SizedBox(height: 2),
+                      Text(
+                        _miniAppTitle(app),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 17,
+                          fontWeight: FontWeight.w900,
+                          color: OSColors.text(dark),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (_miniAppFullRoute(app) != null) ...[
+                  _MiniWindowIconButton(
+                    icon: Icons.open_in_new_rounded,
+                    tooltip: 'Open full page',
+                    onTap: () => context.go(_miniAppFullRoute(app)!),
+                  ),
+                  const SizedBox(width: 6),
+                ],
+                _MiniWindowIconButton(
+                  icon: Icons.close_rounded,
+                  tooltip: 'Close',
+                  onTap: onClose,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Flexible(
+              child: SingleChildScrollView(
+                child: _miniAppBody(context),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 
-  Widget _buildFolderContent(BuildContext context) {
-    return switch (folder) {
-      _HomeWorkspaceFolder.today => _TodayFolderContent(
+  Widget _miniAppBody(BuildContext context) {
+    return switch (app) {
+      _HomeMiniApp.messages => _MessagesMiniAppContent(unread: unread),
+      _HomeMiniApp.agenda => _AgendaMiniAppContent(
+          title: 'Review today\'s plan',
           primaryClass: primaryClass,
           reminders: reminders,
-          unread: unread,
           now: now,
         ),
-      _HomeWorkspaceFolder.classes => _ClassesFolderContent(classes: classes),
-      _HomeWorkspaceFolder.tasks => _TasksFolderContent(
+      _HomeMiniApp.audio => const _FocusAudioMiniAppContent(),
+      _HomeMiniApp.today => _AgendaMiniAppContent(
+          title: _formatLongDate(now),
+          primaryClass: primaryClass,
           reminders: reminders,
           now: now,
+          showClass: true,
         ),
-      _HomeWorkspaceFolder.messages => _MessagesFolderContent(unread: unread),
-      _HomeWorkspaceFolder.insights => _InsightsFolderContent(
+      _HomeMiniApp.classes => _ClassesFolderContent(classes: classes),
+      _HomeMiniApp.tasks => _TasksFolderContent(reminders: reminders, now: now),
+      _HomeMiniApp.insights => _InsightsFolderContent(
           classCount: classes.length,
           totalStudents: totalStudents,
           unread: unread,
@@ -1749,86 +1672,760 @@ class _HomeWorkspaceFolderPanel extends StatelessWidget {
   }
 }
 
-class _TodayFolderContent extends StatelessWidget {
-  const _TodayFolderContent({
-    required this.primaryClass,
-    required this.reminders,
-    required this.unread,
-    required this.now,
+class _MiniWindowIconButton extends StatelessWidget {
+  const _MiniWindowIconButton({
+    required this.icon,
+    required this.tooltip,
+    required this.onTap,
   });
 
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return Tooltip(
+      message: tooltip,
+      child: OSTouchFeedback(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(14),
+        minSize: const Size(34, 34),
+        child: Container(
+          width: 34,
+          height: 34,
+          decoration: BoxDecoration(
+            color: dark
+                ? Colors.white.withValues(alpha: 0.055)
+                : Colors.white.withValues(alpha: 0.60),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: dark
+                  ? Colors.white.withValues(alpha: 0.070)
+                  : Colors.white.withValues(alpha: 0.70),
+            ),
+          ),
+          child: Icon(icon, size: 17, color: OSColors.textSecondary(dark)),
+        ),
+      ),
+    );
+  }
+}
+
+String _miniAppTitle(_HomeMiniApp app) {
+  return switch (app) {
+    _HomeMiniApp.messages => 'Messages',
+    _HomeMiniApp.agenda => 'Agenda / Today\'s Plan',
+    _HomeMiniApp.audio => 'Focus Audio',
+    _HomeMiniApp.today => 'Today',
+    _HomeMiniApp.classes => 'Classes',
+    _HomeMiniApp.tasks => 'Tasks',
+    _HomeMiniApp.insights => 'Insights',
+  };
+}
+
+IconData _miniAppIcon(_HomeMiniApp app) {
+  return switch (app) {
+    _HomeMiniApp.messages => Icons.forum_rounded,
+    _HomeMiniApp.agenda => Icons.event_available_rounded,
+    _HomeMiniApp.audio => Icons.graphic_eq_rounded,
+    _HomeMiniApp.today => Icons.today_rounded,
+    _HomeMiniApp.classes => Icons.class_rounded,
+    _HomeMiniApp.tasks => Icons.task_alt_rounded,
+    _HomeMiniApp.insights => Icons.insights_rounded,
+  };
+}
+
+Color _miniAppAccent(_HomeMiniApp app) {
+  return switch (app) {
+    _HomeMiniApp.messages => OSColors.cyan,
+    _HomeMiniApp.agenda => OSColors.amber,
+    _HomeMiniApp.audio => OSColors.indigo,
+    _HomeMiniApp.today => OSColors.blue,
+    _HomeMiniApp.classes => OSColors.green,
+    _HomeMiniApp.tasks => OSColors.amber,
+    _HomeMiniApp.insights => OSColors.indigo,
+  };
+}
+
+String? _miniAppFullRoute(_HomeMiniApp app) {
+  return switch (app) {
+    _HomeMiniApp.messages => AppRoutes.communication,
+    _HomeMiniApp.agenda ||
+    _HomeMiniApp.today ||
+    _HomeMiniApp.tasks =>
+      AppRoutes.osPlanner,
+    _HomeMiniApp.classes || _HomeMiniApp.insights => AppRoutes.classes,
+    _HomeMiniApp.audio => null,
+  };
+}
+
+class _MessagesMiniAppContent extends StatelessWidget {
+  const _MessagesMiniAppContent({required this.unread});
+
+  final int unread;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    final conversations = [
+      (
+        sender: unread == 0 ? 'Staff room' : 'Unread channels',
+        snippet: unread == 0
+            ? 'Recent class and staff threads are ready.'
+            : '$unread conversation${unread == 1 ? '' : 's'} waiting for review.',
+        status: unread == 0 ? 'quiet' : 'now',
+        accent: OSColors.cyan,
+        unread: unread > 0,
+      ),
+      (
+        sender: 'Class channels',
+        snippet: 'Families, students, and staff threads.',
+        status: 'live',
+        accent: OSColors.blue,
+        unread: false,
+      ),
+      (
+        sender: 'Announcements',
+        snippet: 'School-wide updates and broadcast notes.',
+        status: 'school',
+        accent: OSColors.indigo,
+        unread: false,
+      ),
+    ];
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final wide = constraints.maxWidth > 560;
+        final list = Column(
+          children: [
+            _MiniSearchField(label: 'Search conversations'),
+            const SizedBox(height: 10),
+            for (int index = 0; index < conversations.length; index++) ...[
+              _FolderMessagePreview(
+                sender: conversations[index].sender,
+                snippet: conversations[index].snippet,
+                status: conversations[index].status,
+                unread: conversations[index].unread,
+                accent: conversations[index].accent,
+                onTap: () {},
+              ),
+              if (index != conversations.length - 1) const SizedBox(height: 8),
+            ],
+          ],
+        );
+
+        final thread = Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            color: dark
+                ? Colors.white.withValues(alpha: 0.032)
+                : Colors.white.withValues(alpha: 0.58),
+            borderRadius: BorderRadius.circular(22),
+            border: Border.all(
+              color: dark
+                  ? Colors.white.withValues(alpha: 0.055)
+                  : Colors.white.withValues(alpha: 0.68),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  _MiniAvatar(label: unread == 0 ? 'S' : 'U'),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      unread == 0 ? 'Staff room' : 'Unread channels',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w900,
+                        color: OSColors.text(dark),
+                      ),
+                    ),
+                  ),
+                  _StatusPill(
+                    label: unread == 0 ? 'quiet' : '$unread unread',
+                    accent: unread == 0 ? OSColors.green : OSColors.urgent,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 14),
+              _MessageBubble(
+                text: unread == 0
+                    ? 'No urgent messages are waiting right now.'
+                    : 'There are updates waiting for review before your next handoff.',
+                incoming: true,
+              ),
+              const SizedBox(height: 8),
+              const _MessageBubble(
+                text:
+                    'Open full messages when you need to reply or manage channels.',
+                incoming: false,
+              ),
+              const SizedBox(height: 12),
+              _MiniInputBar(label: 'Reply from full Messages'),
+            ],
+          ),
+        );
+
+        if (!wide) {
+          return Column(children: [list, const SizedBox(height: 12), thread]);
+        }
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(width: 250, child: list),
+            const SizedBox(width: 12),
+            Expanded(child: thread),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _AgendaMiniAppContent extends StatelessWidget {
+  const _AgendaMiniAppContent({
+    required this.title,
+    required this.primaryClass,
+    required this.reminders,
+    required this.now,
+    this.showClass = false,
+  });
+
+  final String title;
   final Class? primaryClass;
   final List<TeacherWorkspaceReminderSnapshot> reminders;
-  final int unread;
+  final DateTime now;
+  final bool showClass;
+
+  @override
+  Widget build(BuildContext context) {
+    final visible = reminders.take(4).toList();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: _PlannerDayCard(title: title, now: now),
+            ),
+            const SizedBox(width: 10),
+            const _MiniMonthPreview(),
+          ],
+        ),
+        if (showClass && primaryClass != null) ...[
+          const SizedBox(height: 10),
+          _FolderInfoRow(
+            icon: Icons.class_rounded,
+            accent: OSColors.green,
+            label: 'Class workspace',
+            value: '${primaryClass!.className} / ${primaryClass!.subject}',
+            onTap: () => context.go(
+              AppRoutes.osClassWorkspace(primaryClass!.classId),
+            ),
+          ),
+        ],
+        const SizedBox(height: 12),
+        Text(
+          reminders.isEmpty ? 'Planner check' : 'Upcoming reminders',
+          style: TextStyle(
+            fontSize: 13,
+            fontWeight: FontWeight.w900,
+            color: OSColors.text(context.isDark),
+          ),
+        ),
+        const SizedBox(height: 8),
+        if (visible.isEmpty)
+          const _AgendaEmptyState()
+        else
+          for (int index = 0; index < visible.length; index++) ...[
+            _ReminderTile(reminder: visible[index], now: now),
+            if (index != visible.length - 1) const SizedBox(height: 8),
+          ],
+      ],
+    );
+  }
+}
+
+class _FocusAudioMiniAppContent extends StatelessWidget {
+  const _FocusAudioMiniAppContent();
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    final stations = [
+      ('Classroom sound', 'Quiet work and transitions', OSColors.cyan),
+      ('Deep focus', 'Low-distraction study bed', OSColors.indigo),
+      ('Bell reset', 'Short transition cue', OSColors.amber),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(14),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: dark
+                  ? const [Color(0xFF1B2137), Color(0xFF101827)]
+                  : const [Color(0xFFFFFFFF), Color(0xFFEAF4FF)],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(24),
+            border: Border.all(
+              color: dark
+                  ? Colors.white.withValues(alpha: 0.075)
+                  : Colors.white.withValues(alpha: 0.80),
+            ),
+          ),
+          child: Row(
+            children: [
+              const _AudioArtwork(),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const _PanelEyebrow(label: 'Now Playing'),
+                    const SizedBox(height: 5),
+                    Text(
+                      'Classroom sound',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w900,
+                        color: OSColors.text(dark),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Stations for quiet work and transitions.',
+                      style: TextStyle(color: OSColors.textSecondary(dark)),
+                    ),
+                    const SizedBox(height: 12),
+                    ClipRRect(
+                      borderRadius: OSRadius.pillBr,
+                      child: LinearProgressIndicator(
+                        minHeight: 5,
+                        value: 0.58,
+                        backgroundColor:
+                            Colors.white.withValues(alpha: dark ? 0.08 : 0.46),
+                        valueColor:
+                            const AlwaysStoppedAnimation<Color>(OSColors.cyan),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              _RoundPlayButton(size: 46),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(child: _StationList(stations: stations)),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: dark
+                      ? Colors.white.withValues(alpha: 0.030)
+                      : Colors.white.withValues(alpha: 0.56),
+                  borderRadius: BorderRadius.circular(22),
+                  border: Border.all(
+                    color: dark
+                        ? Colors.white.withValues(alpha: 0.055)
+                        : Colors.white.withValues(alpha: 0.68),
+                  ),
+                ),
+                child: const Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _PanelEyebrow(label: 'Signal'),
+                    SizedBox(height: 12),
+                    _MiniEqualizer(),
+                    SizedBox(height: 14),
+                    _MiniInputBar(label: 'Add station'),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _MiniSearchField extends StatelessWidget {
+  const _MiniSearchField({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: dark
+            ? Colors.white.withValues(alpha: 0.035)
+            : Colors.white.withValues(alpha: 0.62),
+        borderRadius: OSRadius.pillBr,
+        border: Border.all(
+          color: dark
+              ? Colors.white.withValues(alpha: 0.055)
+              : Colors.white.withValues(alpha: 0.72),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.search_rounded, size: 16, color: OSColors.textMuted(dark)),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: TextStyle(fontSize: 12, color: OSColors.textMuted(dark)),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MiniAvatar extends StatelessWidget {
+  const _MiniAvatar({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 34,
+      height: 34,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: LinearGradient(
+          colors: [
+            OSColors.cyan.withValues(alpha: 0.44),
+            OSColors.indigo.withValues(alpha: 0.24),
+          ],
+        ),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.w900,
+          color: Colors.white,
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusPill extends StatelessWidget {
+  const _StatusPill({required this.label, required this.accent});
+
+  final String label;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+      decoration: BoxDecoration(
+        color: accent.withValues(alpha: context.isDark ? 0.16 : 0.10),
+        borderRadius: OSRadius.pillBr,
+        border: Border.all(color: accent.withValues(alpha: 0.20)),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 10.5,
+          fontWeight: FontWeight.w900,
+          color: accent,
+        ),
+      ),
+    );
+  }
+}
+
+class _MessageBubble extends StatelessWidget {
+  const _MessageBubble({required this.text, required this.incoming});
+
+  final String text;
+  final bool incoming;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return Align(
+      alignment: incoming ? Alignment.centerLeft : Alignment.centerRight,
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 320),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 9),
+        decoration: BoxDecoration(
+          color: incoming
+              ? (dark
+                  ? Colors.white.withValues(alpha: 0.050)
+                  : Colors.white.withValues(alpha: 0.72))
+              : OSColors.cyan.withValues(alpha: dark ? 0.18 : 0.12),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(
+            color: incoming
+                ? (dark
+                    ? Colors.white.withValues(alpha: 0.060)
+                    : Colors.white.withValues(alpha: 0.80))
+                : OSColors.cyan.withValues(alpha: 0.20),
+          ),
+        ),
+        child: Text(
+          text,
+          style: TextStyle(
+            fontSize: 12.5,
+            height: 1.35,
+            color: OSColors.text(dark),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MiniInputBar extends StatelessWidget {
+  const _MiniInputBar({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: dark
+            ? Colors.white.withValues(alpha: 0.035)
+            : Colors.white.withValues(alpha: 0.62),
+        borderRadius: OSRadius.pillBr,
+        border: Border.all(
+          color: dark
+              ? Colors.white.withValues(alpha: 0.055)
+              : Colors.white.withValues(alpha: 0.72),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              label,
+              style: TextStyle(fontSize: 12, color: OSColors.textMuted(dark)),
+            ),
+          ),
+          Icon(Icons.arrow_forward_rounded,
+              size: 16, color: OSColors.textMuted(dark)),
+        ],
+      ),
+    );
+  }
+}
+
+class _PlannerDayCard extends StatelessWidget {
+  const _PlannerDayCard({required this.title, required this.now});
+
+  final String title;
   final DateTime now;
 
   @override
   Widget build(BuildContext context) {
-    final visibleReminders = reminders.take(2).toList();
-    return _FolderPanelScaffold(
-      eyebrow: 'Today',
-      title: _formatLongDate(now),
-      subtitle: primaryClass == null
-          ? 'Check today\'s schedule before calling the next move.'
-          : 'Class tools are ready without assuming the timetable is final.',
-      actionLabel: primaryClass == null ? 'Check Planner' : 'Open Class',
-      actionIcon: Icons.arrow_forward_rounded,
-      onAction: () => context.go(
-        primaryClass == null
-            ? AppRoutes.osPlanner
-            : AppRoutes.osClassWorkspace(primaryClass!.classId),
+    final dark = context.isDark;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            OSColors.blue.withValues(alpha: dark ? 0.13 : 0.08),
+            Colors.white.withValues(alpha: dark ? 0.035 : 0.62),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(
+          color: dark
+              ? Colors.white.withValues(alpha: 0.060)
+              : Colors.white.withValues(alpha: 0.72),
+        ),
       ),
-      secondaryLabel: 'View Schedule',
-      onSecondary: () => context.go(AppRoutes.osPlanner),
       child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _FolderInfoRow(
-            icon: primaryClass == null
-                ? Icons.calendar_month_rounded
-                : Icons.class_rounded,
-            accent: OSColors.green,
-            label: primaryClass == null ? 'Now / Next' : 'Class workspace',
-            value: primaryClass == null
-                ? 'Review schedule'
-                : '${primaryClass!.className} / ${primaryClass!.subject}',
-            onTap: () => context.go(
-              primaryClass == null
-                  ? AppRoutes.osPlanner
-                  : AppRoutes.osClassWorkspace(primaryClass!.classId),
+          const _PanelEyebrow(label: 'Plan'),
+          const SizedBox(height: 6),
+          Text(
+            title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.w900,
+              color: OSColors.text(dark),
             ),
           ),
-          if (unread > 0) ...[
-            const SizedBox(height: 10),
-            _FolderInfoRow(
-              icon: Icons.mark_chat_unread_rounded,
-              accent: OSColors.cyan,
-              label: 'Attention',
-              value: '$unread unread message${unread == 1 ? '' : 's'}',
-              onTap: () => context.go(AppRoutes.communication),
+          const SizedBox(height: 6),
+          Text(
+            'Check schedule before relying on imported timetable details.',
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 12,
+              height: 1.35,
+              color: OSColors.textSecondary(dark),
             ),
-          ],
-          if (visibleReminders.isEmpty) ...[
-            const SizedBox(height: 10),
-            _FolderInfoRow(
-              icon: Icons.calendar_month_rounded,
-              accent: OSColors.blue,
-              label: 'Planner',
-              value: 'Check today\'s schedule',
-              onTap: () => context.go(AppRoutes.osPlanner),
-            ),
-          ] else
-            for (int index = 0; index < visibleReminders.length; index++) ...[
-              const SizedBox(height: 10),
-              _FolderInfoRow(
-                icon: Icons.event_note_outlined,
-                accent: OSColors.amber,
-                label: _relativeReminderLabel(visibleReminders[index], now),
-                value: _trimLine(visibleReminders[index].text, 82),
-                onTap: () => context.go(AppRoutes.osPlanner),
-              ),
-            ],
+          ),
         ],
       ),
+    );
+  }
+}
+
+class _MiniMonthPreview extends StatelessWidget {
+  const _MiniMonthPreview();
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return Container(
+      width: 132,
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: dark
+            ? Colors.white.withValues(alpha: 0.032)
+            : Colors.white.withValues(alpha: 0.58),
+        borderRadius: BorderRadius.circular(22),
+        border: Border.all(
+          color: dark
+              ? Colors.white.withValues(alpha: 0.055)
+              : Colors.white.withValues(alpha: 0.68),
+        ),
+      ),
+      child: Column(
+        children: [
+          const _PanelEyebrow(label: 'Month'),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 5,
+            runSpacing: 5,
+            children: [
+              for (int index = 0; index < 14; index++)
+                Container(
+                  width: 12,
+                  height: 12,
+                  decoration: BoxDecoration(
+                    color: index == 5
+                        ? OSColors.amber
+                        : OSColors.textMuted(dark).withValues(alpha: 0.20),
+                    shape: BoxShape.circle,
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _RoundPlayButton extends StatelessWidget {
+  const _RoundPlayButton({required this.size});
+
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        gradient: const LinearGradient(
+          colors: [Color(0xFF6D5DFB), Color(0xFF22D3EE)],
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: OSColors.indigo.withValues(alpha: 0.18),
+            blurRadius: 14,
+            offset: const Offset(0, 7),
+          ),
+        ],
+      ),
+      child: const Icon(Icons.play_arrow_rounded, color: Colors.white),
+    );
+  }
+}
+
+class _StationList extends StatelessWidget {
+  const _StationList({required this.stations});
+
+  final List<(String, String, Color)> stations;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return Column(
+      children: [
+        for (int index = 0; index < stations.length; index++) ...[
+          Container(
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              color: dark
+                  ? Colors.white.withValues(alpha: 0.032)
+                  : Colors.white.withValues(alpha: 0.58),
+              borderRadius: BorderRadius.circular(18),
+              border: Border.all(
+                color: stations[index].$3.withValues(alpha: 0.16),
+              ),
+            ),
+            child: Row(
+              children: [
+                Icon(Icons.radio_rounded, size: 18, color: stations[index].$3),
+                const SizedBox(width: 9),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        stations[index].$1,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 12.5,
+                          fontWeight: FontWeight.w900,
+                          color: OSColors.text(dark),
+                        ),
+                      ),
+                      Text(
+                        stations[index].$2,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: OSColors.textSecondary(dark),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          if (index != stations.length - 1) const SizedBox(height: 8),
+        ],
+      ],
     );
   }
 }
@@ -1908,58 +2505,6 @@ class _TasksFolderContent extends StatelessWidget {
               ),
               if (index != visible.length - 1) const SizedBox(height: 10),
             ],
-        ],
-      ),
-    );
-  }
-}
-
-class _MessagesFolderContent extends StatelessWidget {
-  const _MessagesFolderContent({required this.unread});
-
-  final int unread;
-
-  @override
-  Widget build(BuildContext context) {
-    return _FolderPanelScaffold(
-      eyebrow: 'Messages',
-      title: unread == 0
-          ? 'Inbox quiet'
-          : '$unread unread update${unread == 1 ? '' : 's'}',
-      subtitle: unread == 0
-          ? 'Conversation previews stay ready here.'
-          : 'Review active threads before they interrupt class flow.',
-      actionLabel: 'Open Messages',
-      actionIcon: Icons.forum_rounded,
-      onAction: () => context.go(AppRoutes.communication),
-      child: Column(
-        children: [
-          _FolderMessagePreview(
-            sender: unread == 0 ? 'Staff room' : 'Unread channels',
-            snippet: unread == 0
-                ? 'Recent class and staff threads are ready.'
-                : '$unread conversation${unread == 1 ? '' : 's'} waiting for review.',
-            status: unread == 0 ? 'quiet' : 'now',
-            unread: unread > 0,
-            accent: OSColors.cyan,
-            onTap: () => context.go(AppRoutes.communication),
-          ),
-          const SizedBox(height: 10),
-          _FolderMessagePreview(
-            sender: 'Class channels',
-            snippet: 'Families, students, and staff threads.',
-            status: 'live',
-            accent: OSColors.blue,
-            onTap: () => context.go(AppRoutes.communication),
-          ),
-          const SizedBox(height: 10),
-          _FolderMessagePreview(
-            sender: 'Announcements',
-            snippet: 'School-wide updates and broadcast notes.',
-            status: 'school',
-            accent: OSColors.indigo,
-            onTap: () => context.go(AppRoutes.communication),
-          ),
         ],
       ),
     );
@@ -2495,13 +3040,22 @@ class _HomeStackedLayout extends StatefulWidget {
 }
 
 class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
-  static const String _folderTapRegionGroup = 'home-folder-workspace-stacked';
-  _HomeWorkspaceFolder? _selectedFolder;
+  static const String _miniAppTapRegionGroup = 'home-mini-app-stacked';
+  _HomeMiniApp? _selectedMiniApp;
 
-  void _closeSelectedFolder() {
-    if (_selectedFolder != null) {
-      setState(() => _selectedFolder = null);
+  void _closeMiniApp() {
+    if (_selectedMiniApp != null) {
+      setState(() => _selectedMiniApp = null);
     }
+  }
+
+  void _openMiniApp(_HomeMiniApp app) {
+    setState(() => _selectedMiniApp = app);
+  }
+
+  void _toggleFolder(_HomeWorkspaceFolder folder) {
+    final app = _miniAppForFolder(folder);
+    setState(() => _selectedMiniApp = _selectedMiniApp == app ? null : app);
   }
 
   @override
@@ -2536,47 +3090,45 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
             reminderCount: widget.reminders.length,
             now: widget.now,
             compact: true,
+            onMessagesTap: () => _openMiniApp(_HomeMiniApp.messages),
+            onPlannerTap: () => _openMiniApp(_HomeMiniApp.agenda),
+            onClassesTap: () => _openMiniApp(_HomeMiniApp.classes),
           ),
         ),
         const SizedBox(height: 14),
-        TapRegion(
-          groupId: _folderTapRegionGroup,
-          onTapOutside: (_) => _closeSelectedFolder(),
-          child: _HomeWorkspaceFolderStrip(
-            selected: _selectedFolder,
-            classCount: widget.classes.length,
-            reminderCount: widget.reminders.length,
-            unread: widget.unread,
-            onSelected: (folder) => setState(() {
-              _selectedFolder = _selectedFolder == folder ? null : folder;
-            }),
-          ),
+        _HomeWorkspaceFolderStrip(
+          selected: _folderForMiniApp(_selectedMiniApp),
+          classCount: widget.classes.length,
+          reminderCount: widget.reminders.length,
+          unread: widget.unread,
+          onSelected: _toggleFolder,
         ),
         AnimatedSwitcher(
           duration: const Duration(milliseconds: 240),
           switchInCurve: Curves.easeOutCubic,
           switchOutCurve: Curves.easeInOut,
           transitionBuilder: _homeFolderTransition,
-          child: _selectedFolder == null
+          child: _selectedMiniApp == null
               ? const Padding(
                   key: ValueKey('workspace-closed'),
                   padding: EdgeInsets.only(top: 14),
                   child: _HomeCalmWorkspaceFloor(),
                 )
               : TapRegion(
-                  groupId: _folderTapRegionGroup,
-                  onTapOutside: (_) => _closeSelectedFolder(),
+                  groupId: _miniAppTapRegionGroup,
+                  onTapOutside: (_) => _closeMiniApp(),
                   child: Padding(
-                    key: ValueKey(_selectedFolder),
+                    key: ValueKey(_selectedMiniApp),
                     padding: const EdgeInsets.only(top: 14),
-                    child: _HomeWorkspaceFolderPanel(
-                      folder: _selectedFolder!,
+                    child: _HomeMiniAppWindow(
+                      app: _selectedMiniApp!,
                       primaryClass: widget.primaryClass,
                       classes: widget.classes,
                       reminders: widget.reminders,
                       unread: widget.unread,
                       totalStudents: widget.totalStudents,
                       now: widget.now,
+                      onClose: _closeMiniApp,
                     ),
                   ),
                 ),
@@ -2585,13 +3137,16 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
         _HomeShortcutShelf(
           unread: widget.unread,
           onLauncherTap: widget.onLauncherTap,
+          onMessagesTap: () => _openMiniApp(_HomeMiniApp.messages),
         ),
         const SizedBox(height: 16),
         _HomeUtilityRail(
           unread: widget.unread,
           reminders: widget.reminders,
           reminderCount: widget.reminders.length,
-          onAudioTap: () => context.go(AppRoutes.dashboard),
+          onAudioTap: () => _openMiniApp(_HomeMiniApp.audio),
+          onMessagesTap: () => _openMiniApp(_HomeMiniApp.messages),
+          onAgendaTap: () => _openMiniApp(_HomeMiniApp.agenda),
         ),
         const SizedBox(height: 112),
       ],
@@ -3410,6 +3965,9 @@ class _HomeStagePanel extends StatelessWidget {
     required this.reminderCount,
     required this.now,
     required this.compact,
+    required this.onMessagesTap,
+    required this.onPlannerTap,
+    required this.onClassesTap,
   });
 
   final String teacherName;
@@ -3422,6 +3980,9 @@ class _HomeStagePanel extends StatelessWidget {
   final int reminderCount;
   final DateTime now;
   final bool compact;
+  final VoidCallback onMessagesTap;
+  final VoidCallback onPlannerTap;
+  final VoidCallback onClassesTap;
 
   @override
   Widget build(BuildContext context) {
@@ -3520,11 +4081,7 @@ class _HomeStagePanel extends StatelessWidget {
                         detail: primaryClass == null
                             ? 'Open Classes to start your first workspace.'
                             : primaryClass!.subject,
-                        onTap: primaryClass == null
-                            ? null
-                            : () => context.go(
-                                  '${AppRoutes.osClass}/${primaryClass!.classId}',
-                                ),
+                        onTap: primaryClass == null ? onClassesTap : null,
                       ),
                       const SizedBox(height: 12),
                       _StageSpotlightTile(
@@ -3537,7 +4094,7 @@ class _HomeStagePanel extends StatelessWidget {
                         detail: primaryReminder == null
                             ? 'Your day is currently clear.'
                             : _trimLine(primaryReminder!.text, 88),
-                        onTap: () => context.go(AppRoutes.osPlanner),
+                        onTap: onPlannerTap,
                       ),
                     ],
                   ),
@@ -3552,6 +4109,9 @@ class _HomeStagePanel extends StatelessWidget {
               classCount: classCount,
               unread: unread,
               now: now,
+              onMessagesTap: onMessagesTap,
+              onPlannerTap: onPlannerTap,
+              onClassesTap: onClassesTap,
             ),
     );
   }
@@ -3566,6 +4126,9 @@ class _DesktopStageShell extends StatelessWidget {
     required this.classCount,
     required this.unread,
     required this.now,
+    required this.onMessagesTap,
+    required this.onPlannerTap,
+    required this.onClassesTap,
   });
 
   final String teacherName;
@@ -3575,6 +4138,9 @@ class _DesktopStageShell extends StatelessWidget {
   final int classCount;
   final int unread;
   final DateTime now;
+  final VoidCallback onMessagesTap;
+  final VoidCallback onPlannerTap;
+  final VoidCallback onClassesTap;
 
   @override
   Widget build(BuildContext context) {
@@ -3588,7 +4154,7 @@ class _DesktopStageShell extends StatelessWidget {
     final primaryActionLabel = unread > 0
         ? 'Messages'
         : primaryClass != null
-            ? 'Open Class'
+            ? 'Classes'
             : 'Planner';
     final primaryActionIcon = unread > 0
         ? Icons.forum_rounded
@@ -3596,11 +4162,10 @@ class _DesktopStageShell extends StatelessWidget {
             ? Icons.arrow_forward_rounded
             : Icons.calendar_month_rounded;
     final primaryAction = unread > 0
-        ? () => context.go(AppRoutes.communication)
+        ? onMessagesTap
         : primaryClass != null
-            ? () =>
-                context.go(AppRoutes.osClassWorkspace(primaryClass!.classId))
-            : () => context.go(AppRoutes.osPlanner);
+            ? onClassesTap
+            : onPlannerTap;
     // TODO: Reconnect Now/Next state after timetable import reliability is fixed.
     final commandTitle = primaryReminder != null
         ? 'Planner needs review'
@@ -3857,11 +4422,13 @@ class _HomeShortcutShelf extends StatelessWidget {
   const _HomeShortcutShelf({
     required this.unread,
     required this.onLauncherTap,
+    required this.onMessagesTap,
     this.compact = false,
   });
 
   final int unread;
   final VoidCallback onLauncherTap;
+  final VoidCallback onMessagesTap;
   final bool compact;
 
   @override
@@ -3876,7 +4443,7 @@ class _HomeShortcutShelf extends StatelessWidget {
       ),
       _shortcutFromApp(
         OSAppId.messages,
-        onTap: () => context.go(AppRoutes.communication),
+        onTap: onMessagesTap,
         badge: unread > 0 ? '$unread' : null,
       ),
       if (showLauncher)
@@ -4481,19 +5048,18 @@ class _HomeAudioPanel extends StatelessWidget {
   const _HomeAudioPanel({
     required this.onTap,
     this.embedded = false,
-    this.framed = true,
-    super.key,
+    this.compact = false,
   });
 
   final VoidCallback onTap;
   final bool embedded;
-  final bool framed;
+  final bool compact;
 
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
     final content = Container(
-      padding: const EdgeInsets.all(13),
+      padding: EdgeInsets.all(compact ? 11 : 13),
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(22),
         gradient: LinearGradient(
@@ -4515,8 +5081,10 @@ class _HomeAudioPanel extends StatelessWidget {
           Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              const _AudioArtwork(),
-              const SizedBox(width: 12),
+              if (!compact) ...[
+                const _AudioArtwork(),
+                const SizedBox(width: 12),
+              ],
               Expanded(
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -4547,31 +5115,10 @@ class _HomeAudioPanel extends StatelessWidget {
                   ],
                 ),
               ),
-              Container(
-                width: 34,
-                height: 34,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  gradient: const LinearGradient(
-                    colors: [Color(0xFF6D5DFB), Color(0xFF22D3EE)],
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: OSColors.indigo.withValues(alpha: 0.18),
-                      blurRadius: 14,
-                      offset: const Offset(0, 7),
-                    ),
-                  ],
-                ),
-                child: const Icon(
-                  Icons.play_arrow_rounded,
-                  size: 22,
-                  color: Colors.white,
-                ),
-              ),
+              _RoundPlayButton(size: compact ? 32 : 34),
             ],
           ),
-          const SizedBox(height: 12),
+          SizedBox(height: compact ? 9 : 12),
           ClipRRect(
             borderRadius: OSRadius.pillBr,
             child: LinearProgressIndicator(
@@ -4584,7 +5131,7 @@ class _HomeAudioPanel extends StatelessWidget {
               ),
             ),
           ),
-          const SizedBox(height: 10),
+          SizedBox(height: compact ? 8 : 10),
           Row(
             children: [
               const Expanded(child: _MiniEqualizer()),
@@ -4612,16 +5159,14 @@ class _HomeAudioPanel extends StatelessWidget {
       onTap: onTap,
       borderRadius: BorderRadius.circular(28),
       minSize: const Size(180, 118),
-      child: !framed
-          ? content
-          : embedded
-              ? _RailSection(child: content)
-              : _GlassPanel(
-                  tone: _HomePanelTone.whisper,
-                  radius: 28,
-                  padding: const EdgeInsets.all(16),
-                  child: content,
-                ),
+      child: embedded
+          ? _RailSection(child: content)
+          : _GlassPanel(
+              tone: _HomePanelTone.whisper,
+              radius: 28,
+              padding: const EdgeInsets.all(16),
+              child: content,
+            ),
     );
   }
 }
@@ -4718,19 +5263,20 @@ class _HomeAgendaPanel extends StatelessWidget {
     required this.reminders,
     required this.scrollable,
     this.embedded = false,
-    this.framed = true,
-    super.key,
+    this.compact = false,
+    this.onTap,
   });
 
   final List<TeacherWorkspaceReminderSnapshot> reminders;
   final bool scrollable;
   final bool embedded;
-  final bool framed;
+  final bool compact;
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
     final visibleReminders =
-        scrollable ? reminders : reminders.take(4).toList();
+        scrollable ? reminders : reminders.take(compact ? 1 : 4).toList();
     final dark = context.isDark;
     final headerChildren = <Widget>[
       Row(
@@ -4774,35 +5320,37 @@ class _HomeAgendaPanel extends StatelessWidget {
           ),
         ],
       ),
-      const SizedBox(height: 10),
-      Container(
-        width: double.infinity,
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
-        decoration: BoxDecoration(
-          color: dark
-              ? Colors.white.withValues(alpha: 0.030)
-              : Colors.white.withValues(alpha: 0.46),
-          borderRadius: BorderRadius.circular(14),
-          border: Border.all(
+      if (!compact) ...[
+        const SizedBox(height: 10),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
+          decoration: BoxDecoration(
             color: dark
-                ? Colors.white.withValues(alpha: 0.045)
-                : Colors.white.withValues(alpha: 0.58),
+                ? Colors.white.withValues(alpha: 0.030)
+                : Colors.white.withValues(alpha: 0.46),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: dark
+                  ? Colors.white.withValues(alpha: 0.045)
+                  : Colors.white.withValues(alpha: 0.58),
+            ),
+          ),
+          child: Text(
+            reminders.isEmpty
+                ? 'The planning lane is calm.'
+                : 'Priority items stay visible without crowding the workspace.',
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 11.5,
+              height: 1.34,
+              color: OSColors.textSecondary(dark),
+            ),
           ),
         ),
-        child: Text(
-          reminders.isEmpty
-              ? 'The planning lane is calm.'
-              : 'Priority items stay visible without crowding the workspace.',
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-          style: TextStyle(
-            fontSize: 11.5,
-            height: 1.34,
-            color: OSColors.textSecondary(dark),
-          ),
-        ),
-      ),
-      const SizedBox(height: 10),
+      ],
+      SizedBox(height: compact ? 8 : 10),
     ];
 
     final content = scrollable
@@ -4863,18 +5411,25 @@ class _HomeAgendaPanel extends StatelessWidget {
             ],
           );
 
-    if (!framed) return content;
+    final tappableContent = onTap == null
+        ? content
+        : OSTouchFeedback(
+            onTap: onTap!,
+            borderRadius: BorderRadius.circular(22),
+            minSize: const Size(180, 108),
+            child: IgnorePointer(child: content),
+          );
 
     return embedded
         ? _RailSection(
             expand: scrollable,
-            child: content,
+            child: tappableContent,
           )
         : _GlassPanel(
             tone: _HomePanelTone.whisper,
             radius: 28,
             padding: const EdgeInsets.all(16),
-            child: content,
+            child: tappableContent,
           );
   }
 }

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -433,11 +433,13 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
 
   @override
   Widget build(BuildContext context) {
+    const sideRailWidth = 260.0;
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         SizedBox(
-          width: 248,
+          width: sideRailWidth,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
@@ -460,8 +462,10 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                   compact: true,
                 ),
               ),
-              const Spacer(),
-              _HomeQuickClassesStrip(classes: widget.classes),
+              const SizedBox(height: 14),
+              Expanded(
+                child: _HomeQuickClassesStrip(classes: widget.classes),
+              ),
             ],
           ),
         ),
@@ -543,7 +547,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
         ),
         const SizedBox(width: 16),
         SizedBox(
-          width: 296,
+          width: sideRailWidth,
           child: _HomeUtilityRail(
             unread: widget.unread,
             reminderCount: widget.reminders.length,
@@ -654,75 +658,183 @@ class _HomeQuickClassesStrip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
-    final visible = classes.take(4).toList();
+    final visible = classes;
 
     return _GlassPanel(
       tone: _HomePanelTone.rail,
-      radius: 24,
-      padding: const EdgeInsets.fromLTRB(12, 12, 12, 14),
+      radius: 26,
+      padding: const EdgeInsets.fromLTRB(14, 14, 14, 14),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
-        mainAxisSize: MainAxisSize.min,
         children: [
-          Row(
-            children: [
-              Icon(
-                Icons.grid_view_rounded,
-                size: 15,
-                color: OSColors.textMuted(dark),
-              ),
-              const SizedBox(width: 7),
-              Expanded(
-                child: Text(
-                  'Quick Classes',
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    fontSize: 11,
-                    fontWeight: FontWeight.w800,
-                    color: OSColors.textSecondary(dark),
-                  ),
-                ),
-              ),
-            ],
+          Text(
+            'Open the next class workspace directly.',
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontSize: 13,
+              height: 1.2,
+              fontWeight: FontWeight.w600,
+              color: OSColors.textSecondary(dark),
+            ),
           ),
-          const SizedBox(height: 10),
+          const SizedBox(height: 12),
           if (visible.isEmpty)
-            _HomeQuickClassTile(
-              label: 'Open classes',
-              detail: 'Set up the first workspace',
-              accent: OSColors.green,
+            _HomeQuickClassEmptyCard(
               onTap: () => context.go(AppRoutes.classes),
             )
           else
-            for (int index = 0; index < visible.length; index++) ...[
-              _HomeQuickClassTile(
-                label: visible[index].className,
-                detail: visible[index].subject,
-                accent: _classAccent(index),
-                onTap: () => context.go(
-                  AppRoutes.osClassWorkspace(visible[index].classId),
+            Expanded(
+              child: Scrollbar(
+                thumbVisibility: visible.length > 2,
+                child: ListView.separated(
+                  padding: EdgeInsets.zero,
+                  itemCount: visible.length,
+                  itemBuilder: (context, index) {
+                    return _HomeQuickClassCard(classItem: visible[index]);
+                  },
+                  separatorBuilder: (context, index) =>
+                      const SizedBox(height: 8),
                 ),
               ),
-              if (index != visible.length - 1) const SizedBox(height: 8),
-            ],
+            ),
+          const SizedBox(height: 12),
+          Divider(
+            height: 1,
+            indent: 28,
+            endIndent: 28,
+            color: dark
+                ? Colors.white.withValues(alpha: 0.08)
+                : Colors.black.withValues(alpha: 0.08),
+          ),
         ],
       ),
     );
   }
 }
 
-class _HomeQuickClassTile extends StatelessWidget {
-  const _HomeQuickClassTile({
-    required this.label,
-    required this.detail,
-    required this.accent,
-    required this.onTap,
-  });
+class _HomeQuickClassCard extends StatelessWidget {
+  const _HomeQuickClassCard({required this.classItem});
 
-  final String label;
-  final String detail;
-  final Color accent;
+  final Class classItem;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    final classId = classItem.classId;
+
+    return OSTouchFeedback(
+      onTap: () => context.go(AppRoutes.osClassWorkspace(classId)),
+      borderRadius: BorderRadius.circular(18),
+      minSize: const Size(204, 68),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(10, 10, 10, 10),
+        decoration: BoxDecoration(
+          color: dark
+              ? Colors.white.withValues(alpha: 0.034)
+              : Colors.white.withValues(alpha: 0.58),
+          borderRadius: BorderRadius.circular(18),
+          border: Border.all(
+            color: dark
+                ? Colors.white.withValues(alpha: 0.052)
+                : Colors.white.withValues(alpha: 0.64),
+          ),
+        ),
+        child: Row(
+          children: [
+            const _HomeQuickClassIcon(),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    classItem.className,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 14,
+                      height: 1.05,
+                      fontWeight: FontWeight.w900,
+                      color: OSColors.text(dark),
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    classItem.subject,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 12,
+                      height: 1.05,
+                      fontWeight: FontWeight.w600,
+                      color: OSColors.textSecondary(dark),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Icon(
+              Icons.chevron_right_rounded,
+              size: 20,
+              color: OSColors.textMuted(dark),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeQuickClassIcon extends StatelessWidget {
+  const _HomeQuickClassIcon();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            OSColors.green.withValues(alpha: 0.92),
+            OSColors.cyan.withValues(alpha: 0.74),
+          ],
+        ),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Center(
+        child: Container(
+          width: 18,
+          height: 22,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Align(
+            alignment: Alignment.topCenter,
+            child: Padding(
+              padding: const EdgeInsets.only(top: 5),
+              child: Icon(
+                Icons.bookmark_rounded,
+                size: 8,
+                color: OSColors.green.withValues(alpha: 0.86),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _HomeQuickClassEmptyCard extends StatelessWidget {
+  const _HomeQuickClassEmptyCard({required this.onTap});
+
   final VoidCallback onTap;
 
   @override
@@ -731,61 +843,60 @@ class _HomeQuickClassTile extends StatelessWidget {
 
     return OSTouchFeedback(
       onTap: onTap,
-      borderRadius: BorderRadius.circular(16),
-      minSize: const Size(180, 48),
+      borderRadius: BorderRadius.circular(18),
+      minSize: const Size(204, 72),
       child: Container(
-        padding: const EdgeInsets.fromLTRB(10, 9, 10, 9),
+        padding: const EdgeInsets.all(10),
         decoration: BoxDecoration(
           color: dark
-              ? Colors.white.withValues(alpha: 0.036)
-              : Colors.white.withValues(alpha: 0.62),
-          borderRadius: BorderRadius.circular(16),
+              ? Colors.white.withValues(alpha: 0.045)
+              : Colors.white.withValues(alpha: 0.68),
+          borderRadius: BorderRadius.circular(18),
           border: Border.all(
-            color: accent.withValues(alpha: dark ? 0.18 : 0.16),
+            color: dark
+                ? Colors.white.withValues(alpha: 0.075)
+                : Colors.white.withValues(alpha: 0.72),
           ),
         ),
         child: Row(
           children: [
-            Container(
-              width: 8,
-              height: 28,
-              decoration: BoxDecoration(
-                color: accent.withValues(alpha: dark ? 0.70 : 0.82),
-                borderRadius: OSRadius.pillBr,
-              ),
-            ),
-            const SizedBox(width: 10),
+            const _HomeQuickClassIcon(),
+            const SizedBox(width: 12),
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   Text(
-                    label,
+                    'Open classes',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(
-                      fontSize: 12,
-                      fontWeight: FontWeight.w800,
+                      fontSize: 17,
+                      height: 1.05,
+                      fontWeight: FontWeight.w900,
                       color: OSColors.text(dark),
                     ),
                   ),
-                  const SizedBox(height: 2),
+                  const SizedBox(height: 6),
                   Text(
-                    detail,
-                    maxLines: 1,
+                    'Set up the first workspace',
+                    maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                     style: TextStyle(
-                      fontSize: 10.5,
-                      color: OSColors.textMuted(dark),
+                      fontSize: 12,
+                      height: 1.1,
+                      fontWeight: FontWeight.w500,
+                      color: OSColors.textSecondary(dark),
                     ),
                   ),
                 ],
               ),
             ),
+            const SizedBox(width: 6),
             Icon(
               Icons.chevron_right_rounded,
-              size: 17,
+              size: 24,
               color: OSColors.textMuted(dark),
             ),
           ],
@@ -1035,27 +1146,48 @@ class _HomeCalmWorkspaceFloor extends StatelessWidget {
     final dark = context.isDark;
 
     return SizedBox(
-      height: 214,
+      height: 224,
       child: Stack(
         alignment: Alignment.topCenter,
         children: [
           Positioned(
-            left: 18,
-            right: 18,
-            top: 18,
-            bottom: 28,
-            child: DecoratedBox(
+            top: 0,
+            left: 64,
+            right: 64,
+            child: Container(
+              height: 18,
               decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(30),
-                border: Border.all(
-                  color: dark
-                      ? Colors.white.withValues(alpha: 0.045)
-                      : Colors.white.withValues(alpha: 0.42),
+                borderRadius: const BorderRadius.vertical(
+                  bottom: Radius.circular(18),
                 ),
                 gradient: LinearGradient(
                   colors: [
-                    Colors.white.withValues(alpha: dark ? 0.028 : 0.32),
-                    Colors.white.withValues(alpha: dark ? 0.010 : 0.10),
+                    OSColors.blue.withValues(alpha: dark ? 0.10 : 0.14),
+                    Colors.white.withValues(alpha: dark ? 0.018 : 0.18),
+                    OSColors.cyan.withValues(alpha: dark ? 0.06 : 0.10),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            left: 16,
+            right: 16,
+            top: 12,
+            bottom: 24,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(28),
+                border: Border.all(
+                  color: dark
+                      ? Colors.white.withValues(alpha: 0.040)
+                      : Colors.white.withValues(alpha: 0.38),
+                ),
+                gradient: LinearGradient(
+                  colors: [
+                    Colors.white.withValues(alpha: dark ? 0.026 : 0.30),
+                    OSColors.blue.withValues(alpha: dark ? 0.012 : 0.045),
+                    Colors.white.withValues(alpha: dark ? 0.008 : 0.09),
                   ],
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
@@ -1066,8 +1198,8 @@ class _HomeCalmWorkspaceFloor extends StatelessWidget {
           Positioned(
             left: 44,
             right: 44,
-            top: 42,
-            bottom: 52,
+            top: 34,
+            bottom: 48,
             child: Container(
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(28),
@@ -1113,7 +1245,7 @@ class _HomeWorkspaceFolderPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     return _GlassPanel(
       tone: _HomePanelTone.whisper,
-      radius: 28,
+      radius: 26,
       padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
       child: ConstrainedBox(
         constraints: const BoxConstraints(minHeight: 176, maxHeight: 276),
@@ -1325,31 +1457,30 @@ class _MessagesFolderContent extends StatelessWidget {
       onAction: () => context.go(AppRoutes.communication),
       child: Column(
         children: [
-          _FolderInfoRow(
-            icon: unread == 0
-                ? Icons.mark_email_read_outlined
-                : Icons.mark_chat_unread_outlined,
+          _FolderMessagePreview(
+            sender: unread == 0 ? 'Staff room' : 'Unread channels',
+            snippet: unread == 0
+                ? 'Recent class and staff threads are ready.'
+                : '$unread conversation${unread == 1 ? '' : 's'} waiting for review.',
+            status: unread == 0 ? 'quiet' : 'now',
+            unread: unread > 0,
             accent: OSColors.cyan,
-            label: unread == 0 ? 'Staff room' : 'Unread',
-            value: unread == 0
-                ? 'Open recent channels'
-                : '$unread conversation${unread == 1 ? '' : 's'} need review',
             onTap: () => context.go(AppRoutes.communication),
           ),
           const SizedBox(height: 10),
-          _FolderInfoRow(
-            icon: Icons.groups_2_outlined,
+          _FolderMessagePreview(
+            sender: 'Class channels',
+            snippet: 'Families, students, and staff threads.',
+            status: 'live',
             accent: OSColors.blue,
-            label: 'Class channels',
-            value: 'Families, students, and staff threads',
             onTap: () => context.go(AppRoutes.communication),
           ),
           const SizedBox(height: 10),
-          _FolderInfoRow(
-            icon: Icons.campaign_outlined,
+          _FolderMessagePreview(
+            sender: 'Announcements',
+            snippet: 'School-wide updates and broadcast notes.',
+            status: 'school',
             accent: OSColors.indigo,
-            label: 'Announcements',
-            value: 'Review school-wide updates',
             onTap: () => context.go(AppRoutes.communication),
           ),
         ],
@@ -1547,7 +1678,7 @@ class _FolderInfoRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final dark = context.isDark;
     final row = Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 9),
       decoration: BoxDecoration(
         color: dark
             ? Colors.white.withValues(alpha: 0.035)
@@ -1561,31 +1692,44 @@ class _FolderInfoRow extends StatelessWidget {
       ),
       child: Row(
         children: [
-          Icon(icon, size: 17, color: accent),
-          const SizedBox(width: 10),
-          SizedBox(
-            width: 98,
-            child: Text(
-              label,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontSize: 11,
-                fontWeight: FontWeight.w800,
-                color: OSColors.text(dark),
+          Container(
+            width: 30,
+            height: 30,
+            decoration: BoxDecoration(
+              color: accent.withValues(alpha: dark ? 0.14 : 0.10),
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(
+                color: accent.withValues(alpha: dark ? 0.22 : 0.16),
               ),
             ),
+            child: Icon(icon, size: 16, color: accent),
           ),
           const SizedBox(width: 10),
           Expanded(
-            child: Text(
-              value,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontSize: 12,
-                color: OSColors.textSecondary(dark),
-              ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w800,
+                    color: OSColors.text(dark),
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  value,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 11.5,
+                    color: OSColors.textSecondary(dark),
+                  ),
+                ),
+              ],
             ),
           ),
           if (onTap != null) ...[
@@ -1607,6 +1751,150 @@ class _FolderInfoRow extends StatelessWidget {
       borderRadius: BorderRadius.circular(18),
       minSize: const Size(220, 46),
       child: row,
+    );
+  }
+}
+
+class _FolderMessagePreview extends StatelessWidget {
+  const _FolderMessagePreview({
+    required this.sender,
+    required this.snippet,
+    required this.status,
+    required this.accent,
+    required this.onTap,
+    this.unread = false,
+  });
+
+  final String sender;
+  final String snippet;
+  final String status;
+  final Color accent;
+  final VoidCallback onTap;
+  final bool unread;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    final preview = Container(
+      padding: const EdgeInsets.all(10),
+      decoration: BoxDecoration(
+        color: dark
+            ? Colors.white.withValues(alpha: 0.035)
+            : Colors.white.withValues(alpha: 0.58),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(
+          color: unread
+              ? accent.withValues(alpha: 0.28)
+              : (dark
+                  ? Colors.white.withValues(alpha: 0.055)
+                  : Colors.white.withValues(alpha: 0.68)),
+        ),
+      ),
+      child: Row(
+        children: [
+          Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Container(
+                width: 34,
+                height: 34,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: LinearGradient(
+                    colors: [
+                      accent.withValues(alpha: dark ? 0.42 : 0.30),
+                      accent.withValues(alpha: dark ? 0.16 : 0.12),
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                ),
+                child: Text(
+                  sender.trim().isEmpty ? '?' : sender.trim()[0],
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w900,
+                    color: dark ? Colors.white : accent,
+                  ),
+                ),
+              ),
+              if (unread)
+                Positioned(
+                  right: -1,
+                  top: -1,
+                  child: Container(
+                    width: 9,
+                    height: 9,
+                    decoration: BoxDecoration(
+                      color: OSColors.urgent,
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: dark ? const Color(0xFF0F172A) : Colors.white,
+                        width: 1.5,
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        sender,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w900,
+                          color: OSColors.text(dark),
+                        ),
+                      ),
+                    ),
+                    Text(
+                      status,
+                      style: TextStyle(
+                        fontSize: 10,
+                        fontWeight: FontWeight.w800,
+                        color: unread ? accent : OSColors.textMuted(dark),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  snippet,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 11.5,
+                    color: OSColors.textSecondary(dark),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Icon(
+            Icons.chevron_right_rounded,
+            size: 18,
+            color: OSColors.textMuted(dark),
+          ),
+        ],
+      ),
+    );
+
+    return OSTouchFeedback(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(18),
+      minSize: const Size(220, 54),
+      child: preview,
     );
   }
 }
@@ -3412,7 +3700,7 @@ class _WeatherWidgetFrame extends StatelessWidget {
     final radius = BorderRadius.circular(embedded ? 24 : 28);
 
     return Container(
-      padding: const EdgeInsets.all(16),
+      padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
         borderRadius: radius,
         gradient: LinearGradient(
@@ -3428,8 +3716,8 @@ class _WeatherWidgetFrame extends StatelessWidget {
             color: _weatherAccentColor(mood, dark).withValues(
               alpha: dark ? 0.12 : 0.10,
             ),
-            blurRadius: 22,
-            offset: const Offset(0, 10),
+            blurRadius: 24,
+            offset: const Offset(0, 12),
           ),
         ],
       ),
@@ -3464,16 +3752,51 @@ class _WeatherAtmospherePainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
+    final softGlow = Paint()
+      ..shader = RadialGradient(
+        colors: [
+          _weatherAccentColor(mood, dark).withValues(alpha: dark ? 0.20 : 0.26),
+          Colors.transparent,
+        ],
+      ).createShader(
+        Rect.fromCircle(
+          center: Offset(size.width * .82, size.height * .10),
+          radius: size.width * .62,
+        ),
+      );
+    canvas.drawCircle(
+      Offset(size.width * .82, size.height * .10),
+      size.width * .62,
+      softGlow,
+    );
+
     final paint = Paint()..style = PaintingStyle.stroke;
     if (mood == _WeatherMood.rain) {
+      final mist = Paint()
+        ..shader = LinearGradient(
+          colors: [
+            Colors.white.withValues(alpha: dark ? 0.02 : 0.10),
+            Colors.white.withValues(alpha: dark ? 0.10 : 0.22),
+            Colors.transparent,
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ).createShader(Offset.zero & size);
+      canvas.drawRRect(
+        RRect.fromRectAndRadius(
+          Rect.fromLTWH(size.width * .42, 6, size.width * .65, size.height),
+          const Radius.circular(28),
+        ),
+        mist,
+      );
       paint
-        ..color = Colors.white.withValues(alpha: dark ? 0.12 : 0.22)
-        ..strokeWidth = 1.1
+        ..color = Colors.white.withValues(alpha: dark ? 0.15 : 0.26)
+        ..strokeWidth = 1.2
         ..strokeCap = StrokeCap.round;
-      for (double x = 8; x < size.width; x += 22) {
+      for (double x = 4; x < size.width + 24; x += 18) {
         canvas.drawLine(
-          Offset(x, 8),
-          Offset(x - 12, size.height - 10),
+          Offset(x, 2),
+          Offset(x - 16, size.height - 4),
           paint,
         );
       }
@@ -3483,34 +3806,30 @@ class _WeatherAtmospherePainter extends CustomPainter {
     if (mood == _WeatherMood.cloudy) {
       final fill = Paint()
         ..style = PaintingStyle.fill
-        ..color = Colors.white.withValues(alpha: dark ? 0.065 : 0.24);
+        ..color = Colors.white.withValues(alpha: dark ? 0.075 : 0.26);
       canvas.drawOval(
-        Rect.fromLTWH(size.width * .48, 8, size.width * .62, 64),
-        fill,
-      );
+          Rect.fromLTWH(size.width * .46, 4, size.width * .70, 64), fill);
       canvas.drawOval(
-        Rect.fromLTWH(size.width * .36, 32, size.width * .58, 74),
-        fill,
-      );
+          Rect.fromLTWH(size.width * .30, 28, size.width * .72, 82), fill);
+      canvas.drawOval(
+          Rect.fromLTWH(size.width * .64, 54, size.width * .48, 58), fill);
       return;
     }
 
-    final glowPaint = Paint()
-      ..shader = RadialGradient(
-        colors: [
-          Colors.white.withValues(alpha: dark ? 0.14 : 0.30),
-          Colors.transparent,
-        ],
-      ).createShader(
-        Rect.fromCircle(
-          center: Offset(size.width * .84, size.height * .10),
-          radius: 90,
-        ),
+    final sun = Paint()
+      ..color = Colors.white.withValues(
+        alpha: mood == _WeatherMood.night ? 0.16 : 0.34,
       );
-    canvas.drawCircle(
-      Offset(size.width * .84, size.height * .10),
-      90,
-      glowPaint,
+    canvas.drawCircle(Offset(size.width * .86, size.height * .14), 28, sun);
+    paint
+      ..color = Colors.white.withValues(alpha: dark ? 0.07 : 0.18)
+      ..strokeWidth = 1;
+    canvas.drawArc(
+      Rect.fromLTWH(size.width * .52, size.height * .52, size.width * .64, 80),
+      3.35,
+      1.7,
+      false,
+      paint,
     );
   }
 
@@ -3585,9 +3904,9 @@ class _HomeAudioPanel extends StatelessWidget {
   Widget build(BuildContext context) {
     final dark = context.isDark;
     final content = Container(
-      padding: const EdgeInsets.all(14),
+      padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(24),
+        borderRadius: BorderRadius.circular(22),
         gradient: LinearGradient(
           colors: dark
               ? const [Color(0xFF151B2D), Color(0xFF0F172A)]
@@ -3613,13 +3932,13 @@ class _HomeAudioPanel extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     const _PanelEyebrow(label: 'Focus Audio'),
-                    const SizedBox(height: 6),
+                    const SizedBox(height: 5),
                     Text(
                       'Classroom sound',
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
-                        fontSize: 16,
+                        fontSize: 15,
                         fontWeight: FontWeight.w800,
                         color: OSColors.text(dark),
                       ),
@@ -3627,10 +3946,10 @@ class _HomeAudioPanel extends StatelessWidget {
                     const SizedBox(height: 3),
                     Text(
                       'Stations for quiet work and transitions.',
-                      maxLines: 2,
+                      maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
-                        fontSize: 12,
+                        fontSize: 11.5,
                         height: 1.35,
                         color: OSColors.textSecondary(dark),
                       ),
@@ -3639,8 +3958,8 @@ class _HomeAudioPanel extends StatelessWidget {
                 ),
               ),
               Container(
-                width: 34,
-                height: 34,
+                width: 32,
+                height: 32,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
                   color: OSColors.indigo.withValues(alpha: dark ? 0.22 : 0.14),
@@ -3657,6 +3976,19 @@ class _HomeAudioPanel extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 12),
+          ClipRRect(
+            borderRadius: OSRadius.pillBr,
+            child: LinearProgressIndicator(
+              minHeight: 4,
+              value: 0.58,
+              backgroundColor:
+                  Colors.white.withValues(alpha: dark ? 0.08 : 0.46),
+              valueColor: AlwaysStoppedAnimation<Color>(
+                OSColors.cyan.withValues(alpha: dark ? 0.92 : 0.82),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
           Row(
             children: [
               const Expanded(child: _MiniEqualizer()),
@@ -3675,7 +4007,7 @@ class _HomeAudioPanel extends StatelessWidget {
     return OSTouchFeedback(
       onTap: onTap,
       borderRadius: BorderRadius.circular(28),
-      minSize: const Size(180, 104),
+      minSize: const Size(180, 118),
       child: embedded
           ? _RailSection(child: content)
           : _GlassPanel(
@@ -3694,10 +4026,10 @@ class _AudioArtwork extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 54,
-      height: 54,
+      width: 48,
+      height: 48,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(18),
+        borderRadius: BorderRadius.circular(16),
         gradient: const LinearGradient(
           colors: [Color(0xFF4F46E5), Color(0xFF06B6D4)],
           begin: Alignment.topLeft,
@@ -3806,7 +4138,7 @@ class _HomeAgendaPanel extends StatelessWidget {
       const SizedBox(height: 4),
       Text(
         reminders.isEmpty
-            ? 'Nothing is queued right now.'
+            ? 'The planning lane is calm.'
             : 'Priority items stay visible without crowding the workspace.',
         style: TextStyle(
           fontSize: 12,
@@ -3823,29 +4155,7 @@ class _HomeAgendaPanel extends StatelessWidget {
             children: [
               ...headerChildren,
               if (reminders.isEmpty)
-                Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.all(14),
-                  decoration: BoxDecoration(
-                    color: dark
-                        ? Colors.white.withValues(alpha: 0.04)
-                        : Colors.white.withValues(alpha: 0.66),
-                    borderRadius: BorderRadius.circular(20),
-                    border: Border.all(
-                      color: dark
-                          ? Colors.white.withValues(alpha: 0.06)
-                          : Colors.white.withValues(alpha: 0.72),
-                    ),
-                  ),
-                  child: Text(
-                    'Your day is currently clear. New reminders from the planning hub will surface here automatically.',
-                    style: TextStyle(
-                      fontSize: 12,
-                      height: 1.45,
-                      color: OSColors.textSecondary(dark),
-                    ),
-                  ),
-                )
+                const _AgendaEmptyState()
               else
                 for (int index = 0;
                     index < visibleReminders.length;
@@ -3864,29 +4174,7 @@ class _HomeAgendaPanel extends StatelessWidget {
             children: [
               ...headerChildren,
               if (reminders.isEmpty)
-                Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.all(14),
-                  decoration: BoxDecoration(
-                    color: dark
-                        ? Colors.white.withValues(alpha: 0.04)
-                        : Colors.white.withValues(alpha: 0.66),
-                    borderRadius: BorderRadius.circular(20),
-                    border: Border.all(
-                      color: dark
-                          ? Colors.white.withValues(alpha: 0.06)
-                          : Colors.white.withValues(alpha: 0.72),
-                    ),
-                  ),
-                  child: Text(
-                    'Your day is currently clear. New reminders from the planning hub will surface here automatically.',
-                    style: TextStyle(
-                      fontSize: 12,
-                      height: 1.45,
-                      color: OSColors.textSecondary(dark),
-                    ),
-                  ),
-                )
+                const _AgendaEmptyState()
               else
                 Column(
                   children: [
@@ -3933,6 +4221,82 @@ class _HomeAgendaPanel extends StatelessWidget {
   }
 }
 
+class _AgendaEmptyState extends StatelessWidget {
+  const _AgendaEmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            OSColors.blue.withValues(alpha: dark ? 0.11 : 0.07),
+            Colors.white.withValues(alpha: dark ? 0.035 : 0.64),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(
+          color: dark
+              ? Colors.white.withValues(alpha: 0.065)
+              : Colors.white.withValues(alpha: 0.72),
+        ),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 34,
+            height: 34,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: OSColors.green.withValues(alpha: dark ? 0.14 : 0.10),
+              border: Border.all(
+                color: OSColors.green.withValues(alpha: 0.18),
+              ),
+            ),
+            child: const Icon(
+              Icons.check_rounded,
+              size: 18,
+              color: OSColors.green,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'No queued reminders',
+                  style: TextStyle(
+                    fontSize: 12.5,
+                    fontWeight: FontWeight.w900,
+                    color: OSColors.text(dark),
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  'New planner items will appear as a quiet timeline.',
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 11.5,
+                    height: 1.35,
+                    color: OSColors.textSecondary(dark),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _ReminderTile extends StatelessWidget {
   const _ReminderTile({
     required this.reminder,
@@ -3949,11 +4313,11 @@ class _ReminderTile extends StatelessWidget {
     final accent = _reminderAccent(reminder, now);
 
     return Container(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.all(11),
       decoration: BoxDecoration(
         color: dark
-            ? Colors.white.withValues(alpha: 0.04)
-            : Colors.white.withValues(alpha: 0.66),
+            ? Colors.white.withValues(alpha: 0.035)
+            : Colors.white.withValues(alpha: 0.62),
         borderRadius: BorderRadius.circular(18),
         border: Border.all(
           color: dark
@@ -3964,16 +4328,31 @@ class _ReminderTile extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Container(
-            width: 10,
-            height: 10,
-            margin: const EdgeInsets.only(top: 4),
-            decoration: BoxDecoration(
-              color: accent,
-              shape: BoxShape.circle,
-            ),
+          Column(
+            children: [
+              Container(
+                width: 22,
+                height: 22,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: accent.withValues(alpha: dark ? 0.18 : 0.12),
+                  shape: BoxShape.circle,
+                  border: Border.all(color: accent.withValues(alpha: 0.26)),
+                ),
+                child: Icon(Icons.schedule_rounded, size: 13, color: accent),
+              ),
+              Container(
+                width: 2,
+                height: 42,
+                margin: const EdgeInsets.only(top: 6),
+                decoration: BoxDecoration(
+                  color: accent.withValues(alpha: dark ? 0.24 : 0.16),
+                  borderRadius: OSRadius.pillBr,
+                ),
+              ),
+            ],
           ),
-          const SizedBox(width: 12),
+          const SizedBox(width: 10),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -4291,16 +4670,6 @@ String _formatLongDate(DateTime now) {
     'December',
   ];
   return '${weekdays[now.weekday - 1]}, ${months[now.month - 1]} ${now.day}';
-}
-
-Color _classAccent(int index) {
-  const accents = [
-    OSColors.green,
-    OSColors.blue,
-    OSColors.cyan,
-    OSColors.indigo,
-  ];
-  return accents[index % accents.length];
 }
 
 IconData _weatherIcon(int code) {

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -474,7 +474,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
           child: LayoutBuilder(
             builder: (context, constraints) {
               final stageHeight =
-                  (constraints.maxHeight * 0.31).clamp(232.0, 286.0);
+                  (constraints.maxHeight * 0.18).clamp(142.0, 174.0);
               return Column(
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
@@ -550,19 +550,9 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
           width: sideRailWidth,
           child: _HomeUtilityRail(
             unread: widget.unread,
+            reminders: widget.reminders,
             reminderCount: widget.reminders.length,
-            children: [
-              const _HomeWeatherPanel(embedded: true),
-              _HomeAudioPanel(
-                embedded: true,
-                onTap: () => context.go(AppRoutes.dashboard),
-              ),
-              _HomeAgendaPanel(
-                reminders: widget.reminders,
-                scrollable: true,
-                embedded: true,
-              ),
-            ],
+            onAudioTap: () => context.go(AppRoutes.dashboard),
           ),
         ),
       ],
@@ -570,23 +560,60 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
   }
 }
 
-class _HomeUtilityRail extends StatelessWidget {
+enum _HomeLivePanel { messages, agenda, audio }
+
+class _HomeUtilityRail extends StatefulWidget {
   const _HomeUtilityRail({
-    required this.children,
     required this.unread,
+    required this.reminders,
     required this.reminderCount,
+    required this.onAudioTap,
   });
 
-  final List<Widget> children;
   final int unread;
+  final List<TeacherWorkspaceReminderSnapshot> reminders;
   final int reminderCount;
+  final VoidCallback onAudioTap;
+
+  @override
+  State<_HomeUtilityRail> createState() => _HomeUtilityRailState();
+}
+
+class _HomeUtilityRailState extends State<_HomeUtilityRail> {
+  late _HomeLivePanel _selected = _defaultLivePanel();
+
+  _HomeLivePanel _defaultLivePanel() {
+    if (widget.unread > 0) return _HomeLivePanel.messages;
+    if (widget.reminderCount > 0) return _HomeLivePanel.agenda;
+    return _HomeLivePanel.audio;
+  }
+
+  @override
+  void didUpdateWidget(covariant _HomeUtilityRail oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.unread == widget.unread &&
+        oldWidget.reminderCount == widget.reminderCount) {
+      return;
+    }
+    final nextDefault = _defaultLivePanel();
+    final oldDefault = oldWidget.unread > 0
+        ? _HomeLivePanel.messages
+        : oldWidget.reminderCount > 0
+            ? _HomeLivePanel.agenda
+            : _HomeLivePanel.audio;
+    if (_selected == oldDefault) {
+      _selected = nextDefault;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
     final signalText = [
-      unread == 0 ? 'Inbox quiet' : '$unread unread',
-      reminderCount == 0 ? 'agenda clear' : '$reminderCount queued',
+      widget.unread == 0 ? 'Inbox quiet' : '${widget.unread} unread',
+      widget.reminderCount == 0
+          ? 'agenda clear'
+          : '${widget.reminderCount} queued',
     ].join(' / ');
 
     return _GlassPanel(
@@ -640,11 +667,252 @@ class _HomeUtilityRail extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 14),
-          for (int index = 0; index < children.length; index++) ...[
-            children[index],
-            if (index != children.length - 1) const SizedBox(height: 12),
-          ],
+          const _HomeWeatherPanel(embedded: true),
+          const SizedBox(height: 12),
+          _HomeLiveStack(
+            selected: _selected,
+            unread: widget.unread,
+            reminders: widget.reminders,
+            onAudioTap: widget.onAudioTap,
+            onSelected: (panel) => setState(() => _selected = panel),
+          ),
         ],
+      ),
+    );
+  }
+}
+
+class _HomeLiveStack extends StatelessWidget {
+  const _HomeLiveStack({
+    required this.selected,
+    required this.unread,
+    required this.reminders,
+    required this.onAudioTap,
+    required this.onSelected,
+  });
+
+  final _HomeLivePanel selected;
+  final int unread;
+  final List<TeacherWorkspaceReminderSnapshot> reminders;
+  final VoidCallback onAudioTap;
+  final ValueChanged<_HomeLivePanel> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return _RailSection(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(3),
+            decoration: BoxDecoration(
+              color: dark
+                  ? Colors.white.withValues(alpha: 0.035)
+                  : Colors.white.withValues(alpha: 0.52),
+              borderRadius: OSRadius.pillBr,
+              border: Border.all(
+                color: dark
+                    ? Colors.white.withValues(alpha: 0.045)
+                    : Colors.white.withValues(alpha: 0.64),
+              ),
+            ),
+            child: Row(
+              children: [
+                _LiveStackTab(
+                  label: 'Messages',
+                  icon: Icons.forum_rounded,
+                  selected: selected == _HomeLivePanel.messages,
+                  accent: OSColors.cyan,
+                  onTap: () => onSelected(_HomeLivePanel.messages),
+                ),
+                _LiveStackTab(
+                  label: 'Agenda',
+                  icon: Icons.event_available_rounded,
+                  selected: selected == _HomeLivePanel.agenda,
+                  accent: OSColors.amber,
+                  onTap: () => onSelected(_HomeLivePanel.agenda),
+                ),
+                _LiveStackTab(
+                  label: 'Audio',
+                  icon: Icons.graphic_eq_rounded,
+                  selected: selected == _HomeLivePanel.audio,
+                  accent: OSColors.indigo,
+                  onTap: () => onSelected(_HomeLivePanel.audio),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 240),
+            switchInCurve: Curves.easeOutCubic,
+            switchOutCurve: Curves.easeInOut,
+            transitionBuilder: _homeFolderTransition,
+            child: switch (selected) {
+              _HomeLivePanel.messages => _HomeMessagesWidget(
+                  key: const ValueKey('live-messages'),
+                  unread: unread,
+                ),
+              _HomeLivePanel.agenda => _HomeAgendaPanel(
+                  key: const ValueKey('live-agenda'),
+                  reminders: reminders,
+                  scrollable: false,
+                  embedded: false,
+                  framed: false,
+                ),
+              _HomeLivePanel.audio => _HomeAudioPanel(
+                  key: const ValueKey('live-audio'),
+                  embedded: false,
+                  framed: false,
+                  onTap: onAudioTap,
+                ),
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HomeMessagesWidget extends StatelessWidget {
+  const _HomeMessagesWidget({
+    super.key,
+    required this.unread,
+  });
+
+  final int unread;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: OSColors.cyan.withValues(alpha: dark ? 0.15 : 0.10),
+                border: Border.all(
+                  color: OSColors.cyan.withValues(alpha: 0.20),
+                ),
+              ),
+              child: const Icon(
+                Icons.chat_bubble_outline_rounded,
+                size: 17,
+                color: OSColors.cyan,
+              ),
+            ),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const _PanelEyebrow(label: 'Messages'),
+                  const SizedBox(height: 3),
+                  Text(
+                    unread == 0
+                        ? 'Inbox quiet'
+                        : '$unread unread update${unread == 1 ? '' : 's'}',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w900,
+                      color: OSColors.text(dark),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        _FolderMessagePreview(
+          sender: unread == 0 ? 'Staff room' : 'Unread channels',
+          snippet: unread == 0
+              ? 'Recent class and staff threads are ready.'
+              : '$unread conversation${unread == 1 ? '' : 's'} waiting for review.',
+          status: unread == 0 ? 'quiet' : 'now',
+          unread: unread > 0,
+          accent: OSColors.cyan,
+          onTap: () => context.go(AppRoutes.communication),
+        ),
+        const SizedBox(height: 8),
+        _FolderMessagePreview(
+          sender: 'Class channels',
+          snippet: 'Families, students, and staff threads.',
+          status: 'live',
+          accent: OSColors.blue,
+          onTap: () => context.go(AppRoutes.communication),
+        ),
+      ],
+    );
+  }
+}
+
+class _LiveStackTab extends StatelessWidget {
+  const _LiveStackTab({
+    required this.label,
+    required this.icon,
+    required this.selected,
+    required this.accent,
+    required this.onTap,
+  });
+
+  final String label;
+  final IconData icon;
+  final bool selected;
+  final Color accent;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return Expanded(
+      child: OSTouchFeedback(
+        onTap: onTap,
+        borderRadius: OSRadius.pillBr,
+        minSize: const Size(64, 34),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 8),
+          decoration: BoxDecoration(
+            color: selected
+                ? accent.withValues(alpha: dark ? 0.18 : 0.12)
+                : Colors.transparent,
+            borderRadius: OSRadius.pillBr,
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                icon,
+                size: 14,
+                color: selected ? accent : OSColors.textMuted(dark),
+              ),
+              const SizedBox(width: 4),
+              Flexible(
+                child: Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontSize: 10.5,
+                    fontWeight: FontWeight.w900,
+                    color: selected
+                        ? OSColors.text(dark)
+                        : OSColors.textMuted(dark),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }
@@ -2198,19 +2466,9 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
         const SizedBox(height: 16),
         _HomeUtilityRail(
           unread: widget.unread,
+          reminders: widget.reminders,
           reminderCount: widget.reminders.length,
-          children: [
-            const _HomeWeatherPanel(embedded: true),
-            _HomeAudioPanel(
-              embedded: true,
-              onTap: () => context.go(AppRoutes.dashboard),
-            ),
-            _HomeAgendaPanel(
-              reminders: widget.reminders,
-              scrollable: false,
-              embedded: true,
-            ),
-          ],
+          onAudioTap: () => context.go(AppRoutes.dashboard),
         ),
         const SizedBox(height: 112),
       ],
@@ -3063,7 +3321,7 @@ class _HomeStagePanel extends StatelessWidget {
     return _GlassPanel(
       tone: _HomePanelTone.stage,
       radius: compact ? WorkspaceRadius.shellCompact : WorkspaceRadius.shell,
-      padding: EdgeInsets.all(compact ? 22 : 20),
+      padding: EdgeInsets.all(compact ? 22 : 16),
       gradient: stageGradient,
       child: compact
           ? SingleChildScrollView(
@@ -3198,99 +3456,121 @@ class _DesktopStageShell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
+    final signal = primaryReminder != null
+        ? _relativeReminderLabel(primaryReminder!, now)
+        : unread > 0
+            ? '$unread unread'
+            : 'Quiet';
+    final primaryActionLabel = primaryClass != null
+        ? 'Open Class'
+        : unread > 0
+            ? 'Messages'
+            : 'Planner';
+    final primaryActionIcon = primaryClass != null
+        ? Icons.arrow_forward_rounded
+        : unread > 0
+            ? Icons.forum_rounded
+            : Icons.calendar_month_rounded;
+    final primaryAction = primaryClass != null
+        ? () => context.go(AppRoutes.osClassWorkspace(primaryClass!.classId))
+        : unread > 0
+            ? () => context.go(AppRoutes.communication)
+            : () => context.go(AppRoutes.osPlanner);
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
-        Row(
-          children: [
-            const _PanelEyebrow(label: 'Command Center'),
-            const Spacer(),
-            _StageStatusChip(
-              text: classCount == 0
-                  ? 'No active classes'
-                  : '$classCount active classes',
-            ),
-          ],
-        ),
-        const SizedBox(height: 12),
-        Expanded(
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
+        SizedBox(
+          width: 152,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              SizedBox(
-                width: 245,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    FittedBox(
-                      fit: BoxFit.scaleDown,
-                      alignment: Alignment.centerLeft,
-                      child: Text(
-                        _formatClock(now),
-                        style: TextStyle(
-                          fontSize: 56,
-                          height: 0.88,
-                          fontWeight: FontWeight.w800,
-                          letterSpacing: 0,
-                          color: OSColors.text(dark),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      _formatLongDate(now),
-                      style: TextStyle(
-                        fontSize: 15,
-                        fontWeight: FontWeight.w700,
-                        color: OSColors.textSecondary(dark),
-                      ),
-                    ),
-                  ],
+              const _PanelEyebrow(label: 'Command Center'),
+              const SizedBox(height: 7),
+              FittedBox(
+                fit: BoxFit.scaleDown,
+                alignment: Alignment.centerLeft,
+                child: Text(
+                  _formatClock(now),
+                  style: TextStyle(
+                    fontSize: 34,
+                    height: 0.9,
+                    fontWeight: FontWeight.w900,
+                    letterSpacing: 0,
+                    color: OSColors.text(dark),
+                  ),
                 ),
               ),
-              const SizedBox(width: 24),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      _stageHeadline(teacherName, primaryClass),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontSize: 25,
-                        height: 1.05,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                        color: OSColors.text(dark),
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      _stageSupportLine(
-                        primaryClass: primaryClass,
-                        primaryReminder: primaryReminder,
-                        classCount: classCount,
-                        unread: unread,
-                        schoolName: schoolName,
-                        now: now,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: TextStyle(
-                        fontSize: 12,
-                        height: 1.42,
-                        color: OSColors.textSecondary(dark),
-                      ),
-                    ),
-                  ],
+              const SizedBox(height: 5),
+              Text(
+                _formatDateLine(now),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: OSColors.textSecondary(dark),
                 ),
               ),
             ],
           ),
+        ),
+        const SizedBox(width: 18),
+        Expanded(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  _StageStatusChip(text: signal),
+                  const SizedBox(width: 8),
+                  _StageStatusChip(
+                    text: classCount == 0
+                        ? 'No active classes'
+                        : '$classCount classes',
+                  ),
+                ],
+              ),
+              const SizedBox(height: 9),
+              Text(
+                primaryClass == null
+                    ? 'Planner ready'
+                    : 'Next: ${primaryClass!.className}',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 19,
+                  height: 1.05,
+                  fontWeight: FontWeight.w900,
+                  letterSpacing: 0,
+                  color: OSColors.text(dark),
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                primaryReminder != null
+                    ? _trimLine(primaryReminder!.text, 84)
+                    : primaryClass == null
+                        ? 'Open the planner or create the next class space.'
+                        : '${primaryClass!.subject} / ${classCount == 0 ? 'no classes' : '$classCount active class${classCount == 1 ? '' : 'es'}'}',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontSize: 12,
+                  height: 1.35,
+                  color: OSColors.textSecondary(dark),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: 16),
+        _FolderActionButton(
+          label: primaryActionLabel,
+          icon: primaryActionIcon,
+          onTap: primaryAction,
         ),
       ],
     );
@@ -4062,10 +4342,13 @@ class _HomeAudioPanel extends StatelessWidget {
   const _HomeAudioPanel({
     required this.onTap,
     this.embedded = false,
+    this.framed = true,
+    super.key,
   });
 
   final VoidCallback onTap;
   final bool embedded;
+  final bool framed;
 
   @override
   Widget build(BuildContext context) {
@@ -4190,14 +4473,16 @@ class _HomeAudioPanel extends StatelessWidget {
       onTap: onTap,
       borderRadius: BorderRadius.circular(28),
       minSize: const Size(180, 118),
-      child: embedded
-          ? _RailSection(child: content)
-          : _GlassPanel(
-              tone: _HomePanelTone.whisper,
-              radius: 28,
-              padding: const EdgeInsets.all(16),
-              child: content,
-            ),
+      child: !framed
+          ? content
+          : embedded
+              ? _RailSection(child: content)
+              : _GlassPanel(
+                  tone: _HomePanelTone.whisper,
+                  radius: 28,
+                  padding: const EdgeInsets.all(16),
+                  child: content,
+                ),
     );
   }
 }
@@ -4294,11 +4579,14 @@ class _HomeAgendaPanel extends StatelessWidget {
     required this.reminders,
     required this.scrollable,
     this.embedded = false,
+    this.framed = true,
+    super.key,
   });
 
   final List<TeacherWorkspaceReminderSnapshot> reminders;
   final bool scrollable;
   final bool embedded;
+  final bool framed;
 
   @override
   Widget build(BuildContext context) {
@@ -4435,6 +4723,8 @@ class _HomeAgendaPanel extends StatelessWidget {
                 ),
             ],
           );
+
+    if (!framed) return content;
 
     return embedded
         ? _RailSection(

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -455,7 +455,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
               ),
               const SizedBox(height: 14),
               SizedBox(
-                height: 202,
+                height: 174,
                 child: _HomeShortcutShelf(
                   unread: widget.unread,
                   onLauncherTap: widget.onLauncherTap,
@@ -497,15 +497,18 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                   TapRegion(
                     groupId: _folderTapRegionGroup,
                     onTapOutside: (_) => _closeSelectedFolder(),
-                    child: _HomeWorkspaceFolderStrip(
-                      selected: _selectedFolder,
-                      classCount: widget.classes.length,
-                      reminderCount: widget.reminders.length,
-                      unread: widget.unread,
-                      onSelected: (folder) => setState(() {
-                        _selectedFolder =
-                            _selectedFolder == folder ? null : folder;
-                      }),
+                    child: Align(
+                      alignment: Alignment.center,
+                      child: _HomeWorkspaceFolderStrip(
+                        selected: _selectedFolder,
+                        classCount: widget.classes.length,
+                        reminderCount: widget.reminders.length,
+                        unread: widget.unread,
+                        onSelected: (folder) => setState(() {
+                          _selectedFolder =
+                              _selectedFolder == folder ? null : folder;
+                        }),
+                      ),
                     ),
                   ),
                   const SizedBox(height: 14),
@@ -724,6 +727,7 @@ class _HomeLiveStack extends StatelessWidget {
                   icon: Icons.forum_rounded,
                   selected: selected == _HomeLivePanel.messages,
                   accent: OSColors.cyan,
+                  badge: unread > 0 ? '$unread' : null,
                   onTap: () => onSelected(_HomeLivePanel.messages),
                 ),
                 _LiveStackTab(
@@ -786,50 +790,104 @@ class _HomeMessagesWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
+    final hasUnread = unread > 0;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Row(
-          children: [
-            Container(
-              width: 32,
-              height: 32,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: OSColors.cyan.withValues(alpha: dark ? 0.15 : 0.10),
-                border: Border.all(
-                  color: OSColors.cyan.withValues(alpha: 0.20),
-                ),
-              ),
-              child: const Icon(
-                Icons.chat_bubble_outline_rounded,
-                size: 17,
-                color: OSColors.cyan,
-              ),
+        Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                OSColors.cyan.withValues(alpha: dark ? 0.18 : 0.13),
+                OSColors.blue.withValues(alpha: dark ? 0.08 : 0.07),
+              ],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
             ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+            borderRadius: BorderRadius.circular(22),
+            border: Border.all(
+              color: OSColors.cyan.withValues(alpha: hasUnread ? 0.28 : 0.14),
+            ),
+          ),
+          child: Row(
+            children: [
+              Stack(
+                clipBehavior: Clip.none,
                 children: [
-                  const _PanelEyebrow(label: 'Messages'),
-                  const SizedBox(height: 3),
-                  Text(
-                    unread == 0
-                        ? 'Inbox quiet'
-                        : '$unread unread update${unread == 1 ? '' : 's'}',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w900,
-                      color: OSColors.text(dark),
+                  Container(
+                    width: 38,
+                    height: 38,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color:
+                          OSColors.cyan.withValues(alpha: dark ? 0.18 : 0.13),
+                      border: Border.all(
+                        color: OSColors.cyan.withValues(alpha: 0.24),
+                      ),
+                    ),
+                    child: const Icon(
+                      Icons.chat_bubble_outline_rounded,
+                      size: 19,
+                      color: OSColors.cyan,
                     ),
                   ),
+                  if (hasUnread)
+                    Positioned(
+                      right: -1,
+                      top: -1,
+                      child: Container(
+                        width: 10,
+                        height: 10,
+                        decoration: BoxDecoration(
+                          color: OSColors.urgent,
+                          shape: BoxShape.circle,
+                          border: Border.all(
+                            color:
+                                dark ? const Color(0xFF0F172A) : Colors.white,
+                            width: 1.5,
+                          ),
+                        ),
+                      ),
+                    ),
                 ],
               ),
-            ),
-          ],
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const _PanelEyebrow(label: 'Messages'),
+                    const SizedBox(height: 3),
+                    Text(
+                      hasUnread
+                          ? '$unread unread update${unread == 1 ? '' : 's'}'
+                          : 'Inbox quiet',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w900,
+                        color: OSColors.text(dark),
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      hasUnread
+                          ? 'Review conversations before the next handoff.'
+                          : 'Class and staff threads are standing by.',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 11.5,
+                        color: OSColors.textSecondary(dark),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
         const SizedBox(height: 12),
         _FolderMessagePreview(
@@ -862,6 +920,7 @@ class _LiveStackTab extends StatelessWidget {
     required this.selected,
     required this.accent,
     required this.onTap,
+    this.badge,
   });
 
   final String label;
@@ -869,6 +928,7 @@ class _LiveStackTab extends StatelessWidget {
   final bool selected;
   final Color accent;
   final VoidCallback onTap;
+  final String? badge;
 
   @override
   Widget build(BuildContext context) {
@@ -890,10 +950,34 @@ class _LiveStackTab extends StatelessWidget {
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(
-                icon,
-                size: 14,
-                color: selected ? accent : OSColors.textMuted(dark),
+              Stack(
+                clipBehavior: Clip.none,
+                children: [
+                  Icon(
+                    icon,
+                    size: 14,
+                    color: selected ? accent : OSColors.textMuted(dark),
+                  ),
+                  if (badge != null)
+                    Positioned(
+                      right: -5,
+                      top: -5,
+                      child: Container(
+                        width: 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          color: OSColors.urgent,
+                          shape: BoxShape.circle,
+                          border: Border.all(
+                            color: dark
+                                ? const Color(0xFF172033)
+                                : Colors.white.withValues(alpha: 0.9),
+                            width: 1.2,
+                          ),
+                        ),
+                      ),
+                    ),
+                ],
               ),
               const SizedBox(width: 4),
               Flexible(
@@ -982,9 +1066,13 @@ class _HomeQuickClassesStrip extends StatelessWidget {
 }
 
 class _HomeQuickClassCard extends StatelessWidget {
-  const _HomeQuickClassCard({required this.classItem});
+  const _HomeQuickClassCard({
+    required this.classItem,
+    this.dense = false,
+  });
 
   final Class classItem;
+  final bool dense;
 
   @override
   Widget build(BuildContext context) {
@@ -993,15 +1081,15 @@ class _HomeQuickClassCard extends StatelessWidget {
 
     return OSTouchFeedback(
       onTap: () => context.go(AppRoutes.osClassWorkspace(classId)),
-      borderRadius: BorderRadius.circular(18),
-      minSize: const Size(204, 112),
+      borderRadius: BorderRadius.circular(dense ? 16 : 18),
+      minSize: Size(204, dense ? 92 : 112),
       child: Container(
-        padding: const EdgeInsets.fromLTRB(10, 10, 10, 10),
+        padding: EdgeInsets.fromLTRB(10, dense ? 8 : 10, 10, dense ? 8 : 10),
         decoration: BoxDecoration(
           color: dark
               ? Colors.white.withValues(alpha: 0.034)
               : Colors.white.withValues(alpha: 0.58),
-          borderRadius: BorderRadius.circular(18),
+          borderRadius: BorderRadius.circular(dense ? 16 : 18),
           border: Border.all(
             color: dark
                 ? Colors.white.withValues(alpha: 0.052)
@@ -1012,7 +1100,7 @@ class _HomeQuickClassCard extends StatelessWidget {
           children: [
             Row(
               children: [
-                const _HomeQuickClassIcon(),
+                _HomeQuickClassIcon(size: dense ? 38 : 40),
                 const SizedBox(width: 10),
                 Expanded(
                   child: Column(
@@ -1053,7 +1141,7 @@ class _HomeQuickClassCard extends StatelessWidget {
                 ),
               ],
             ),
-            const SizedBox(height: 10),
+            SizedBox(height: dense ? 8 : 10),
             Row(
               children: [
                 _HomeQuickClassMiniAction(
@@ -1143,13 +1231,15 @@ class _HomeQuickClassMiniAction extends StatelessWidget {
 }
 
 class _HomeQuickClassIcon extends StatelessWidget {
-  const _HomeQuickClassIcon();
+  const _HomeQuickClassIcon({this.size = 40});
+
+  final double size;
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: 40,
-      height: 40,
+      width: size,
+      height: size,
       decoration: BoxDecoration(
         gradient: LinearGradient(
           begin: Alignment.topLeft,
@@ -1159,15 +1249,15 @@ class _HomeQuickClassIcon extends StatelessWidget {
             OSColors.cyan.withValues(alpha: 0.74),
           ],
         ),
-        borderRadius: BorderRadius.circular(14),
+        borderRadius: BorderRadius.circular(size * 0.35),
       ),
       child: Center(
         child: Container(
-          width: 18,
-          height: 22,
+          width: size * 0.45,
+          height: size * 0.55,
           decoration: BoxDecoration(
             color: Colors.white,
-            borderRadius: BorderRadius.circular(4),
+            borderRadius: BorderRadius.circular(size * 0.10),
           ),
           child: Align(
             alignment: Alignment.topCenter,
@@ -1175,7 +1265,7 @@ class _HomeQuickClassIcon extends StatelessWidget {
               padding: const EdgeInsets.only(top: 5),
               child: Icon(
                 Icons.bookmark_rounded,
-                size: 8,
+                size: size * 0.20,
                 color: OSColors.green.withValues(alpha: 0.86),
               ),
             ),
@@ -1296,41 +1386,51 @@ class _HomeWorkspaceFolderStrip extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4),
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: context.isDark
-                ? Colors.white.withValues(alpha: 0.018)
-                : Colors.white.withValues(alpha: 0.24),
-            borderRadius: BorderRadius.circular(22),
-            border: Border.all(
-              color: context.isDark
-                  ? Colors.white.withValues(alpha: 0.035)
-                  : Colors.white.withValues(alpha: 0.36),
-            ),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.all(3),
-            child: Row(
-              children: [
-                for (final folder in _HomeWorkspaceFolder.values) ...[
-                  _HomeWorkspaceFolderChip(
-                    folder: folder,
-                    selected: selected == folder,
-                    detail: _folderDetail(folder),
-                    onTap: () => onSelected(folder),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minWidth: constraints.maxWidth),
+            child: Align(
+              alignment: Alignment.center,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 4),
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: context.isDark
+                        ? Colors.white.withValues(alpha: 0.018)
+                        : Colors.white.withValues(alpha: 0.24),
+                    borderRadius: BorderRadius.circular(22),
+                    border: Border.all(
+                      color: context.isDark
+                          ? Colors.white.withValues(alpha: 0.035)
+                          : Colors.white.withValues(alpha: 0.36),
+                    ),
                   ),
-                  if (folder != _HomeWorkspaceFolder.values.last)
-                    const SizedBox(width: 8),
-                ],
-              ],
+                  child: Padding(
+                    padding: const EdgeInsets.all(3),
+                    child: Row(
+                      children: [
+                        for (final folder in _HomeWorkspaceFolder.values) ...[
+                          _HomeWorkspaceFolderChip(
+                            folder: folder,
+                            selected: selected == folder,
+                            detail: _folderDetail(folder),
+                            onTap: () => onSelected(folder),
+                          ),
+                          if (folder != _HomeWorkspaceFolder.values.last)
+                            const SizedBox(width: 8),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+              ),
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 
@@ -1505,66 +1605,83 @@ class _HomeCalmWorkspaceFloor extends StatelessWidget {
         alignment: Alignment.topCenter,
         children: [
           Positioned(
-            top: 0,
-            left: 64,
-            right: 64,
-            child: Container(
-              height: 18,
-              decoration: BoxDecoration(
-                borderRadius: const BorderRadius.vertical(
-                  bottom: Radius.circular(18),
-                ),
-                gradient: LinearGradient(
-                  colors: [
-                    OSColors.blue.withValues(alpha: dark ? 0.10 : 0.14),
-                    Colors.white.withValues(alpha: dark ? 0.018 : 0.18),
-                    OSColors.cyan.withValues(alpha: dark ? 0.06 : 0.10),
-                  ],
-                ),
-              ),
-            ),
-          ),
-          Positioned(
-            left: 16,
-            right: 16,
-            top: 12,
-            bottom: 24,
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(28),
-                border: Border.all(
-                  color: dark
-                      ? Colors.white.withValues(alpha: 0.040)
-                      : Colors.white.withValues(alpha: 0.38),
-                ),
-                gradient: LinearGradient(
-                  colors: [
-                    Colors.white.withValues(alpha: dark ? 0.026 : 0.30),
-                    OSColors.blue.withValues(alpha: dark ? 0.012 : 0.045),
-                    Colors.white.withValues(alpha: dark ? 0.008 : 0.09),
-                  ],
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
+            top: 4,
+            left: 56,
+            right: 56,
+            child: IgnorePointer(
+              child: Container(
+                height: 42,
+                decoration: BoxDecoration(
+                  borderRadius: const BorderRadius.vertical(
+                    bottom: Radius.circular(40),
+                  ),
+                  gradient: LinearGradient(
+                    colors: [
+                      OSColors.blue.withValues(alpha: dark ? 0.12 : 0.16),
+                      Colors.white.withValues(alpha: dark ? 0.016 : 0.14),
+                      OSColors.cyan.withValues(alpha: dark ? 0.07 : 0.10),
+                    ],
+                  ),
                 ),
               ),
             ),
           ),
           Positioned(
-            left: 44,
-            right: 44,
-            top: 34,
-            bottom: 48,
-            child: Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(28),
-                gradient: RadialGradient(
-                  center: const Alignment(-0.35, -0.45),
-                  radius: 1.0,
-                  colors: [
-                    OSColors.blue.withValues(alpha: dark ? 0.075 : 0.12),
-                    OSColors.cyan.withValues(alpha: dark ? 0.025 : 0.06),
-                    Colors.transparent,
-                  ],
+            left: -12,
+            right: -12,
+            top: 24,
+            bottom: 0,
+            child: IgnorePointer(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: RadialGradient(
+                    center: const Alignment(-0.20, -0.55),
+                    radius: 0.86,
+                    colors: [
+                      OSColors.blue.withValues(alpha: dark ? 0.10 : 0.13),
+                      OSColors.cyan.withValues(alpha: dark ? 0.036 : 0.060),
+                      Colors.transparent,
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            left: 52,
+            right: 52,
+            top: 72,
+            child: IgnorePointer(
+              child: Container(
+                height: 1,
+                decoration: BoxDecoration(
+                  borderRadius: OSRadius.pillBr,
+                  gradient: LinearGradient(
+                    colors: [
+                      Colors.transparent,
+                      Colors.white.withValues(alpha: dark ? 0.10 : 0.34),
+                      Colors.transparent,
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+          Positioned(
+            right: 38,
+            top: 42,
+            child: IgnorePointer(
+              child: Container(
+                width: 112,
+                height: 112,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  gradient: RadialGradient(
+                    colors: [
+                      OSColors.indigo.withValues(alpha: dark ? 0.07 : 0.09),
+                      Colors.transparent,
+                    ],
+                  ),
                 ),
               ),
             ),
@@ -1652,9 +1769,9 @@ class _TodayFolderContent extends StatelessWidget {
       eyebrow: 'Today',
       title: _formatLongDate(now),
       subtitle: primaryClass == null
-          ? 'Start from the class list or check the planning lane.'
-          : 'Your next workspace and near tasks are ready.',
-      actionLabel: primaryClass == null ? 'View Schedule' : 'Open Class',
+          ? 'Check today\'s schedule before calling the next move.'
+          : 'Class tools are ready without assuming the timetable is final.',
+      actionLabel: primaryClass == null ? 'Check Planner' : 'Open Class',
       actionIcon: Icons.arrow_forward_rounded,
       onAction: () => context.go(
         primaryClass == null
@@ -1666,25 +1783,37 @@ class _TodayFolderContent extends StatelessWidget {
       child: Column(
         children: [
           _FolderInfoRow(
-            icon: Icons.class_rounded,
+            icon: primaryClass == null
+                ? Icons.calendar_month_rounded
+                : Icons.class_rounded,
             accent: OSColors.green,
-            label: 'Next class',
+            label: primaryClass == null ? 'Now / Next' : 'Class workspace',
             value: primaryClass == null
-                ? 'No class pinned yet'
+                ? 'Review schedule'
                 : '${primaryClass!.className} / ${primaryClass!.subject}',
             onTap: () => context.go(
               primaryClass == null
-                  ? AppRoutes.classes
+                  ? AppRoutes.osPlanner
                   : AppRoutes.osClassWorkspace(primaryClass!.classId),
             ),
           ),
+          if (unread > 0) ...[
+            const SizedBox(height: 10),
+            _FolderInfoRow(
+              icon: Icons.mark_chat_unread_rounded,
+              accent: OSColors.cyan,
+              label: 'Attention',
+              value: '$unread unread message${unread == 1 ? '' : 's'}',
+              onTap: () => context.go(AppRoutes.communication),
+            ),
+          ],
           if (visibleReminders.isEmpty) ...[
             const SizedBox(height: 10),
             _FolderInfoRow(
               icon: Icons.calendar_month_rounded,
               accent: OSColors.blue,
-              label: 'Schedule',
-              value: 'Open the planning lane',
+              label: 'Planner',
+              value: 'Check today\'s schedule',
               onTap: () => context.go(AppRoutes.osPlanner),
             ),
           ] else
@@ -1717,7 +1846,7 @@ class _ClassesFolderContent extends StatelessWidget {
       title: classes.isEmpty ? 'No active classes' : 'Active class spaces',
       subtitle: classes.isEmpty
           ? 'Create a class to begin staging teaching tools.'
-          : 'Open the class workspace when you are ready to work.',
+          : 'Tap a class, or jump straight to a teaching tool.',
       actionLabel: classes.isEmpty ? 'Open Classes' : 'Open first class',
       actionIcon: Icons.class_rounded,
       onAction: () => context.go(
@@ -1734,15 +1863,7 @@ class _ClassesFolderContent extends StatelessWidget {
             const _FolderEmptyLine('Class workspaces will appear here.')
           else
             for (int index = 0; index < visible.length; index++) ...[
-              _FolderInfoRow(
-                icon: Icons.dashboard_customize_rounded,
-                accent: OSColors.green,
-                label: visible[index].className,
-                value: '${visible[index].subject} / ${visible[index].term}',
-                onTap: () => context.go(
-                  AppRoutes.osClassWorkspace(visible[index].classId),
-                ),
-              ),
+              _HomeQuickClassCard(classItem: visible[index], dense: true),
               if (index != visible.length - 1) const SizedBox(height: 10),
             ],
         ],
@@ -1767,7 +1888,7 @@ class _TasksFolderContent extends StatelessWidget {
       eyebrow: 'Tasks',
       title: reminders.isEmpty ? 'Clear for now' : 'Priority queue',
       subtitle: reminders.isEmpty
-          ? 'No reminders are waiting in the workspace.'
+          ? 'No dated reminders are asking for attention.'
           : '${reminders.length} item${reminders.length == 1 ? '' : 's'} staged from planning.',
       actionLabel: 'Open Planner',
       actionIcon: Icons.calendar_month_rounded,
@@ -1775,7 +1896,7 @@ class _TasksFolderContent extends StatelessWidget {
       child: Column(
         children: [
           if (visible.isEmpty)
-            const _FolderEmptyLine('New planning reminders will appear here.')
+            const _FolderEmptyLine('Planning lane is calm.')
           else
             for (int index = 0; index < visible.length; index++) ...[
               _FolderInfoRow(
@@ -1805,7 +1926,9 @@ class _MessagesFolderContent extends StatelessWidget {
       title: unread == 0
           ? 'Inbox quiet'
           : '$unread unread update${unread == 1 ? '' : 's'}',
-      subtitle: 'A calm preview for school communication, not a full inbox.',
+      subtitle: unread == 0
+          ? 'Conversation previews stay ready here.'
+          : 'Review active threads before they interrupt class flow.',
       actionLabel: 'Open Messages',
       actionIcon: Icons.forum_rounded,
       onAction: () => context.go(AppRoutes.communication),
@@ -1860,8 +1983,8 @@ class _InsightsFolderContent extends StatelessWidget {
   Widget build(BuildContext context) {
     return _FolderPanelScaffold(
       eyebrow: 'Insights',
-      title: 'Teaching load overview',
-      subtitle: 'Lightweight signals only. Detailed analytics can wait.',
+      title: 'Teaching signals',
+      subtitle: 'Compact load, attention, and class health indicators.',
       actionLabel: 'Open Classes',
       actionIcon: Icons.class_rounded,
       onAction: () => context.go(AppRoutes.classes),
@@ -3461,21 +3584,38 @@ class _DesktopStageShell extends StatelessWidget {
         : unread > 0
             ? '$unread unread'
             : 'Quiet';
-    final primaryActionLabel = primaryClass != null
-        ? 'Open Class'
-        : unread > 0
-            ? 'Messages'
+    final needsAttention = primaryReminder != null || unread > 0;
+    final primaryActionLabel = unread > 0
+        ? 'Messages'
+        : primaryClass != null
+            ? 'Open Class'
             : 'Planner';
-    final primaryActionIcon = primaryClass != null
-        ? Icons.arrow_forward_rounded
-        : unread > 0
-            ? Icons.forum_rounded
+    final primaryActionIcon = unread > 0
+        ? Icons.forum_rounded
+        : primaryClass != null
+            ? Icons.arrow_forward_rounded
             : Icons.calendar_month_rounded;
-    final primaryAction = primaryClass != null
-        ? () => context.go(AppRoutes.osClassWorkspace(primaryClass!.classId))
-        : unread > 0
-            ? () => context.go(AppRoutes.communication)
+    final primaryAction = unread > 0
+        ? () => context.go(AppRoutes.communication)
+        : primaryClass != null
+            ? () =>
+                context.go(AppRoutes.osClassWorkspace(primaryClass!.classId))
             : () => context.go(AppRoutes.osPlanner);
+    // TODO: Reconnect Now/Next state after timetable import reliability is fixed.
+    final commandTitle = primaryReminder != null
+        ? 'Planner needs review'
+        : unread > 0
+            ? 'Messages need review'
+            : primaryClass == null
+                ? 'Check today\'s schedule'
+                : 'Class workspace ready';
+    final commandDetail = primaryReminder != null
+        ? _trimLine(primaryReminder!.text, 84)
+        : unread > 0
+            ? 'Open conversations before the next handoff.'
+            : primaryClass == null
+                ? 'Review schedule in Planner.'
+                : '${primaryClass!.className} / ${primaryClass!.subject}';
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -3531,13 +3671,15 @@ class _DesktopStageShell extends StatelessWidget {
                         ? 'No active classes'
                         : '$classCount classes',
                   ),
+                  if (needsAttention) ...[
+                    const SizedBox(width: 8),
+                    const _StageStatusChip(text: 'Attention'),
+                  ],
                 ],
               ),
               const SizedBox(height: 9),
               Text(
-                primaryClass == null
-                    ? 'Planner ready'
-                    : 'Next: ${primaryClass!.className}',
+                commandTitle,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(
@@ -3550,11 +3692,7 @@ class _DesktopStageShell extends StatelessWidget {
               ),
               const SizedBox(height: 6),
               Text(
-                primaryReminder != null
-                    ? _trimLine(primaryReminder!.text, 84)
-                    : primaryClass == null
-                        ? 'Open the planner or create the next class space.'
-                        : '${primaryClass!.subject} / ${classCount == 0 ? 'no classes' : '$classCount active class${classCount == 1 ? '' : 'es'}'}',
+                commandDetail,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
                 style: TextStyle(
@@ -3753,20 +3891,20 @@ class _HomeShortcutShelf extends StatelessWidget {
     return _GlassPanel(
       tone: _HomePanelTone.whisper,
       radius: compact ? 24 : 28,
-      padding: EdgeInsets.all(compact ? 13 : 16),
+      padding: EdgeInsets.all(compact ? 12 : 16),
       child: LayoutBuilder(
         builder: (context, constraints) {
-          final tileWidth = compact ? 72.0 : 82.0;
+          final tileWidth = compact ? 64.0 : 82.0;
 
           return Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               const _PanelEyebrow(label: 'Pinned Apps'),
-              SizedBox(height: compact ? 6 : 8),
+              SizedBox(height: compact ? 5 : 8),
               Text(
                 'Quick launch',
                 style: TextStyle(
-                  fontSize: compact ? 15.5 : 17,
+                  fontSize: compact ? 14.5 : 17,
                   fontWeight: FontWeight.w800,
                   color: OSColors.text(context.isDark),
                 ),
@@ -3782,9 +3920,9 @@ class _HomeShortcutShelf extends StatelessWidget {
                   ),
                 ),
               ],
-              SizedBox(height: compact ? 11 : 14),
+              SizedBox(height: compact ? 9 : 14),
               SizedBox(
-                height: compact ? 86 : 96,
+                height: compact ? 72 : 96,
                 child: ShaderMask(
                   shaderCallback: (rect) {
                     return LinearGradient(
@@ -3806,7 +3944,7 @@ class _HomeShortcutShelf extends StatelessWidget {
                       return _HomeShortcutIcon(
                         data: shortcuts[index],
                         width: tileWidth,
-                        iconBoxSize: compact ? 50 : 58,
+                        iconBoxSize: compact ? 44 : 58,
                       );
                     },
                   ),
@@ -3865,6 +4003,7 @@ class _HomeShortcutIcon extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dark = context.isDark;
+    final compact = iconBoxSize <= 44;
 
     return OSTouchFeedback(
       onTap: data.onTap,
@@ -3925,14 +4064,14 @@ class _HomeShortcutIcon extends StatelessWidget {
                   ),
               ],
             ),
-            const SizedBox(height: 7),
+            SizedBox(height: compact ? 5 : 7),
             Text(
               data.label,
               textAlign: TextAlign.center,
-              maxLines: 2,
+              maxLines: compact ? 1 : 2,
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
-                fontSize: 11,
+                fontSize: compact ? 10.5 : 11,
                 height: 1.2,
                 fontWeight: FontWeight.w600,
                 color: OSColors.textSecondary(dark),

--- a/lib/screens/class_list_screen.dart
+++ b/lib/screens/class_list_screen.dart
@@ -5,6 +5,8 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 import 'package:gradeflow/services/auth_service.dart';
+import 'package:gradeflow/services/class_note_service.dart';
+import 'package:gradeflow/services/class_schedule_service.dart';
 import 'package:gradeflow/services/class_service.dart';
 import 'package:gradeflow/services/demo_data_service.dart';
 import 'package:gradeflow/services/final_exam_service.dart';
@@ -32,6 +34,8 @@ import 'package:gradeflow/services/class_trash_service.dart';
 import 'package:gradeflow/services/ai_import_service.dart';
 import 'package:gradeflow/openai/openai_config.dart';
 import 'package:gradeflow/components/ai_analyze_import_dialog.dart';
+import 'package:gradeflow/models/seating_layout.dart';
+import 'package:gradeflow/repositories/repository_factory.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 enum _ImportSource { local, driveLink, driveBrowse }
@@ -40,6 +44,35 @@ class _PickedBytes {
   final String filename;
   final Uint8List bytes;
   const _PickedBytes({required this.filename, required this.bytes});
+}
+
+class _SemesterSection {
+  const _SemesterSection(this.season, this.part);
+
+  final String season;
+  final int part;
+
+  String get label => '$season $part';
+}
+
+class _ParsedSemesterSection {
+  const _ParsedSemesterSection({
+    required this.season,
+    required this.part,
+  });
+
+  final String? season;
+  final int? part;
+}
+
+class _NextSection {
+  const _NextSection({
+    required this.term,
+    required this.schoolYear,
+  });
+
+  final String term;
+  final String schoolYear;
 }
 
 class ClassListScreen extends StatefulWidget {
@@ -1302,13 +1335,49 @@ class _ClassListScreenState extends State<ClassListScreen> {
     return trimmed;
   }
 
-  String _nextTerm(String term) {
+  _NextSection _nextSection(Class classItem) {
+    final parsed = _parseSection(classItem.term);
+    final next = switch ((parsed.season, parsed.part)) {
+      ('fall', 1) => const _SemesterSection('Fall', 2),
+      ('fall', 2) => const _SemesterSection('Spring', 1),
+      ('spring', 1) => const _SemesterSection('Spring', 2),
+      ('spring', 2) => const _SemesterSection('Fall', 1),
+      ('summer', 1) => const _SemesterSection('Summer', 2),
+      ('summer', 2) => const _SemesterSection('Fall', 1),
+      _ => _fallbackNextSection(classItem.term),
+    };
+
+    final advancesSchoolYear =
+        (parsed.season == 'spring' && parsed.part == 2) ||
+            (parsed.season == 'summer' && parsed.part == 2);
+    return _NextSection(
+      term: next.label,
+      schoolYear: advancesSchoolYear
+          ? _nextSchoolYear(classItem.schoolYear)
+          : classItem.schoolYear,
+    );
+  }
+
+  _SemesterSection _fallbackNextSection(String term) {
     final t = term.trim().toLowerCase();
-    if (t == 'fall' || t == 'autumn') return 'Spring';
-    if (t == 'spring') return 'Fall';
-    if (t == 'summer') return 'Fall';
-    if (t == 'winter') return 'Spring';
-    return term;
+    if (t == 'fall' || t == 'autumn') return const _SemesterSection('Fall', 2);
+    if (t == 'spring') return const _SemesterSection('Spring', 2);
+    if (t == 'summer') return const _SemesterSection('Summer', 2);
+    return const _SemesterSection('Fall', 1);
+  }
+
+  _ParsedSemesterSection _parseSection(String term) {
+    final normalized = term.trim().toLowerCase();
+    final seasonMatch =
+        RegExp(r'(fall|autumn|spring|summer)').firstMatch(normalized);
+    final partMatch = RegExp(r'(?:part|half)?\s*([12])\b')
+        .firstMatch(normalized.replaceAll('-', ' '));
+    final season =
+        seasonMatch?.group(1) == 'autumn' ? 'fall' : seasonMatch?.group(1);
+    return _ParsedSemesterSection(
+      season: season,
+      part: int.tryParse(partMatch?.group(1) ?? ''),
+    );
   }
 
   Future<void> _showStartNewSemesterDialog(Class classItem) async {
@@ -1316,18 +1385,20 @@ class _ClassListScreenState extends State<ClassListScreen> {
     final subjectController = TextEditingController(text: classItem.subject);
     final groupController =
         TextEditingController(text: classItem.groupNumber ?? '');
-    final yearController =
-        TextEditingController(text: _nextSchoolYear(classItem.schoolYear));
-    final termController =
-        TextEditingController(text: _nextTerm(classItem.term));
+    final nextSection = _nextSection(classItem);
+    final yearController = TextEditingController(text: nextSection.schoolYear);
+    final termController = TextEditingController(text: nextSection.term);
     bool archiveCurrent = !classItem.isArchived;
     bool copyStudents = true;
+    bool copyNotes = true;
+    bool copySeating = true;
+    bool copySchedule = true;
 
     final proceed = await showDialog<bool>(
       context: context,
       builder: (ctx) => StatefulBuilder(
         builder: (ctx, setDialogState) => AlertDialog(
-          title: const Text('Start New Semester'),
+          title: const Text('Start New Section'),
           content: SingleChildScrollView(
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -1354,7 +1425,10 @@ class _ClassListScreenState extends State<ClassListScreen> {
                 const SizedBox(height: AppSpacing.md),
                 TextField(
                   controller: termController,
-                  decoration: const InputDecoration(labelText: 'Term'),
+                  decoration: const InputDecoration(
+                    labelText: 'Section',
+                    helperText: 'Fall 1, Fall 2, Spring 1, Spring 2',
+                  ),
                 ),
                 const SizedBox(height: AppSpacing.sm),
                 CheckboxListTile(
@@ -1370,11 +1444,36 @@ class _ClassListScreenState extends State<ClassListScreen> {
                   value: copyStudents,
                   controlAffinity: ListTileControlAffinity.leading,
                   contentPadding: EdgeInsets.zero,
-                  title: const Text('Copy students into new semester class'),
+                  title: const Text('Carry students forward'),
                   subtitle: const Text(
-                      'Grades and assessments are not copied. You can edit roster after creation.'),
+                      'Assessment items, scores, and exams stay archived with the old section.'),
                   onChanged: (v) =>
                       setDialogState(() => copyStudents = v ?? true),
+                ),
+                CheckboxListTile(
+                  value: copySeating,
+                  controlAffinity: ListTileControlAffinity.leading,
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Carry seating forward'),
+                  subtitle: const Text(
+                      'Keeps room layouts, student placements, seat notes, and reminders.'),
+                  onChanged: (v) =>
+                      setDialogState(() => copySeating = v ?? true),
+                ),
+                CheckboxListTile(
+                  value: copyNotes,
+                  controlAffinity: ListTileControlAffinity.leading,
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Carry class notes forward'),
+                  onChanged: (v) => setDialogState(() => copyNotes = v ?? true),
+                ),
+                CheckboxListTile(
+                  value: copySchedule,
+                  controlAffinity: ListTileControlAffinity.leading,
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('Carry schedule forward'),
+                  onChanged: (v) =>
+                      setDialogState(() => copySchedule = v ?? true),
                 ),
               ],
             ),
@@ -1386,7 +1485,7 @@ class _ClassListScreenState extends State<ClassListScreen> {
             ),
             FilledButton(
               onPressed: () => Navigator.pop(ctx, true),
-              child: const Text('Create New Semester Class'),
+              child: const Text('Start Section'),
             ),
           ],
         ),
@@ -1434,6 +1533,7 @@ class _ClassListScreenState extends State<ClassListScreen> {
     final classService = context.read<ClassService>();
     final studentService = context.read<StudentService>();
     final catService = context.read<GradingCategoryService>();
+    final userId = user.userId;
     if (archiveCurrent && !classItem.isArchived) {
       await classService.archiveClass(classItem.classId);
     }
@@ -1454,11 +1554,143 @@ class _ClassListScreenState extends State<ClassListScreen> {
         await studentService.addStudents(copied);
       }
     }
+    if (copySeating) {
+      await _copySeatingForward(
+        sourceClassId: classItem.classId,
+        targetClassId: newClass.classId,
+        timestamp: now,
+      );
+    }
+    if (copyNotes) {
+      final noteService = ClassNoteService();
+      final notes = await noteService.load(
+        classId: classItem.classId,
+        userId: userId,
+      );
+      await noteService.save(
+        classId: newClass.classId,
+        userId: userId,
+        items: notes,
+      );
+    }
+    if (copySchedule) {
+      final scheduleService = ClassScheduleService();
+      final schedule = await scheduleService.load(classItem.classId);
+      await scheduleService.save(newClass.classId, schedule);
+    }
     await classService.loadClasses(user.userId);
     if (!mounted) return;
 
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('New semester class created.')),
+      const SnackBar(
+        content: Text('New section started. Previous section archived.'),
+      ),
+    );
+  }
+
+  Future<void> _showQuickStartSectionDialog(ClassService classService) async {
+    final activeClasses = _orderedActiveClasses(classService.activeClasses);
+    if (activeClasses.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Create a class before starting a section.')),
+      );
+      return;
+    }
+
+    var selectedClassId = activeClasses.first.classId;
+    final selected = await showDialog<Class?>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          title: const Text('Start New Section'),
+          content: SizedBox(
+            width: 420,
+            child: DropdownButtonFormField<String>(
+              initialValue: selectedClassId,
+              isExpanded: true,
+              decoration: const InputDecoration(labelText: 'Current class'),
+              items: [
+                for (final classItem in activeClasses)
+                  DropdownMenuItem(
+                    value: classItem.classId,
+                    child: Text(
+                      '${classItem.className} - ${classItem.term}',
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+              ],
+              onChanged: (value) {
+                if (value == null) return;
+                setDialogState(() => selectedClassId = value);
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final classItem = activeClasses.firstWhere(
+                  (item) => item.classId == selectedClassId,
+                );
+                Navigator.pop(ctx, classItem);
+              },
+              child: const Text('Continue'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (selected == null || !mounted) return;
+    await _showStartNewSemesterDialog(selected);
+  }
+
+  Future<void> _copySeatingForward({
+    required String sourceClassId,
+    required String targetClassId,
+    required DateTime timestamp,
+  }) async {
+    final repo = RepositoryFactory.instance;
+    final layouts = await repo.loadSeatingLayouts(sourceClassId);
+    if (layouts.isNotEmpty) {
+      await repo.saveSeatingLayouts(
+        targetClassId,
+        [
+          for (final layout in layouts)
+            _copySeatingLayoutForClass(
+              layout,
+              targetClassId: targetClassId,
+              timestamp: timestamp,
+            ),
+        ],
+      );
+    }
+
+    final activeLayoutId = await repo.loadActiveSeatingLayoutId(sourceClassId);
+    if (activeLayoutId != null && activeLayoutId.trim().isNotEmpty) {
+      await repo.saveActiveSeatingLayoutId(targetClassId, activeLayoutId);
+    }
+
+    final assignedRoomSetupId =
+        await repo.loadAssignedRoomSetupId(sourceClassId);
+    await repo.saveAssignedRoomSetupId(targetClassId, assignedRoomSetupId);
+  }
+
+  SeatingLayout _copySeatingLayoutForClass(
+    SeatingLayout layout, {
+    required String targetClassId,
+    required DateTime timestamp,
+  }) {
+    return layout.copyWith(
+      classId: targetClassId,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      tables: [for (final table in layout.tables) table.copyWith()],
+      seats: [for (final seat in layout.seats) seat.copyWith()],
     );
   }
 
@@ -2063,7 +2295,7 @@ class _ClassListScreenState extends State<ClassListScreen> {
                       return const [
                         PopupMenuItem(
                             value: 'rollover',
-                            child: Text('Start New Semester')),
+                            child: Text('Start New Section')),
                         PopupMenuItem(
                             value: 'unarchive', child: Text('Unarchive')),
                         PopupMenuItem(value: 'edit', child: Text('Edit')),
@@ -2074,7 +2306,7 @@ class _ClassListScreenState extends State<ClassListScreen> {
                       PopupMenuItem(value: 'edit', child: Text('Edit')),
                       PopupMenuItem(
                           value: 'rollover',
-                          child: Text('Archive + New Semester')),
+                          child: Text('Archive + New Section')),
                       PopupMenuItem(value: 'archive', child: Text('Archive')),
                       PopupMenuItem(value: 'delete', child: Text('Delete')),
                     ];
@@ -2095,7 +2327,7 @@ class _ClassListScreenState extends State<ClassListScreen> {
         : classService.activeClasses.length;
     final summary = _showArchived
         ? '$count archived class${count == 1 ? '' : 'es'} kept ready for rollover, restore, and reporting.'
-        : '$count active class${count == 1 ? '' : 'es'} ready to open, act on, and reorder around your teaching day.';
+        : '$count active class${count == 1 ? '' : 'es'} ready to open, start a new section, and reorder around your teaching day.';
     final importReady = _driveAccessToken != null;
 
     Widget statusPill({
@@ -2200,6 +2432,13 @@ class _ClassListScreenState extends State<ClassListScreen> {
         alignment: WrapAlignment.end,
         children: [
           FilledButton.icon(
+            onPressed: classService.activeClasses.isEmpty
+                ? null
+                : () => _showQuickStartSectionDialog(classService),
+            icon: const Icon(Icons.restart_alt_rounded),
+            label: const Text('Start Section'),
+          ),
+          FilledButton.icon(
             onPressed: _showCreateClassDialog,
             icon: const Icon(Icons.add),
             label: const Text('Create Class'),
@@ -2228,7 +2467,7 @@ class _ClassListScreenState extends State<ClassListScreen> {
             _showArchived ? Icons.inventory_2_outlined : Icons.school_outlined,
         title: _showArchived ? 'No archived classes yet' : 'No classes yet',
         subtitle: _showArchived
-            ? 'Archived classes and semester rollovers will appear here when you need them.'
+            ? 'Archived classes and section rollovers will appear here when you need them.'
             : 'Create your first class or import rosters from Excel, CSV, or Drive to start building your workspace.',
         actions: _showArchived
             ? [
@@ -2352,7 +2591,7 @@ class _ClassListScreenState extends State<ClassListScreen> {
       eyebrow: 'Teacher Workspace',
       title: 'Classes workspace',
       subtitle:
-          'Manage rosters, imports, class lifecycle, and semester rollover from one place that feels ready for daily use.',
+          'Manage rosters, imports, class lifecycle, and section rollover from one place that feels ready for daily use.',
       trailingActions: [
         TextButton.icon(
           onPressed: _driveSigningIn ? null : _ensureDriveAccessToken,

--- a/lib/screens/export_screen.dart
+++ b/lib/screens/export_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:gradeflow/components/animated_page_background.dart';
 import 'package:gradeflow/components/workspace_shell.dart';
@@ -18,7 +19,6 @@ import 'package:gradeflow/services/calculation_service.dart';
 import 'package:gradeflow/services/export_service.dart';
 import 'package:gradeflow/theme.dart';
 import 'package:flutter/foundation.dart' show kIsWeb, debugPrint;
-import 'dart:typed_data';
 import 'package:gradeflow/platform/browser_file_actions.dart';
 import 'package:gradeflow/services/class_service.dart';
 import 'package:gradeflow/services/auth_service.dart';
@@ -27,6 +27,7 @@ import 'package:excel/excel.dart' hide Border;
 import 'package:go_router/go_router.dart';
 import 'package:gradeflow/nav.dart';
 import 'package:gradeflow/components/pdf_web_viewer.dart';
+import 'package:printing/printing.dart';
 
 class ExportScreen extends StatefulWidget {
   final String classId;
@@ -1018,7 +1019,11 @@ class _ExportScreenState extends State<ExportScreen> {
   Future<void> _showPdfPreview(Uint8List bytes,
       {required String title, required String filename}) async {
     if (!kIsWeb) {
-      _showError('PDF preview is only supported on web.');
+      if (bytes.isEmpty) {
+        _showError('Unable to share an empty PDF.');
+        return;
+      }
+      await Printing.sharePdf(bytes: bytes, filename: filename);
       return;
     }
 
@@ -1112,7 +1117,7 @@ class _ExportScreenState extends State<ExportScreen> {
       final ok =
           await _downloadText(csv, 'grades_${widget.classId}.csv', 'text/csv');
       ok
-          ? _showSuccess('Class CSV downloaded')
+          ? _showSuccess(kIsWeb ? 'Class CSV downloaded' : 'Class CSV copied')
           : _showError(
               'Download blocked or failed. Please allow downloads and try again.');
     } else if (_format == _ExportFormat.xlsx) {
@@ -1181,7 +1186,8 @@ class _ExportScreenState extends State<ExportScreen> {
       final ok = await _downloadText(
           csv, 'report_${student.studentId}.csv', 'text/csv');
       ok
-          ? _showSuccess('Student CSV downloaded')
+          ? _showSuccess(
+              kIsWeb ? 'Student CSV downloaded' : 'Student CSV copied')
           : _showError(
               'Download blocked or failed. Please allow downloads and try again.');
     } else if (_format == _ExportFormat.xlsx) {
@@ -1207,7 +1213,8 @@ class _ExportScreenState extends State<ExportScreen> {
         final ok = await _downloadBytes(
             bytes, 'report_${student.studentId}.pdf', 'application/pdf');
         ok
-            ? _showSuccess('Student PDF downloaded')
+            ? _showSuccess(
+                kIsWeb ? 'Student PDF downloaded' : 'Student PDF shared')
             : _showError(
                 'Download blocked or failed. Please allow downloads and try again.');
       } catch (e) {
@@ -1263,8 +1270,9 @@ class _ExportScreenState extends State<ExportScreen> {
         final ok =
             await _downloadText(csv, 'grades_all_classes.csv', 'text/csv');
         ok
-            ? _showSuccess(
-                'All-classes CSV downloaded for ${dataset.classCount} classes')
+            ? _showSuccess(kIsWeb
+                ? 'All-classes CSV downloaded for ${dataset.classCount} classes'
+                : 'All-classes CSV copied for ${dataset.classCount} classes')
             : _showError(
                 'Download blocked or failed. Try "Open in New Tab" or copy CSV.');
       } else if (_format == _ExportFormat.xlsx) {
@@ -1380,8 +1388,15 @@ class _ExportScreenState extends State<ExportScreen> {
     String mime,
   ) async {
     if (!kIsWeb) {
-      _showError('Export is only supported on web');
-      return false;
+      try {
+        await Clipboard.setData(ClipboardData(text: text));
+        debugPrint('Copied $filename export text to clipboard on native.');
+        return true;
+      } catch (e) {
+        debugPrint('Native text export failed for $filename: $e');
+        _showError('Could not copy this export to the clipboard.');
+        return false;
+      }
     }
 
     return downloadBrowserText(text, filename, mime);
@@ -1393,7 +1408,17 @@ class _ExportScreenState extends State<ExportScreen> {
     String mime,
   ) async {
     if (!kIsWeb) {
-      _showError('Export is only supported on web');
+      if (mime == 'application/pdf') {
+        if (bytes.isEmpty) {
+          _showError('Unable to share an empty PDF.');
+          return false;
+        }
+        await Printing.sharePdf(bytes: bytes, filename: filename);
+        return true;
+      }
+      _showError(
+        'Spreadsheet downloads are web-only right now. Use CSV copy or PDF share on this device.',
+      );
       return false;
     }
     if (bytes.isEmpty) {

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -2,10 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
-import 'package:gradeflow/components/animated_page_background.dart';
-import 'package:gradeflow/components/gradeflow_entry_motion.dart';
 import 'package:gradeflow/components/workspace_shell.dart';
-import 'package:gradeflow/config/gradeflow_product_config.dart';
+import 'package:gradeflow/config/instructos_branding.dart';
 import 'package:gradeflow/services/auth_service.dart';
 import 'package:gradeflow/services/class_service.dart';
 import 'package:gradeflow/services/demo_data_service.dart';
@@ -15,7 +13,8 @@ import 'package:gradeflow/services/grading_category_service.dart';
 import 'package:gradeflow/services/student_score_service.dart';
 import 'package:gradeflow/services/student_service.dart';
 import 'package:gradeflow/nav.dart';
-import 'package:gradeflow/theme.dart';
+import 'package:gradeflow/widgets/branding/instructos_auth_card_shell.dart';
+import 'package:gradeflow/widgets/branding/instructos_interactive_auth_background.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -28,7 +27,9 @@ class LoginScreen extends StatefulWidget {
 class _LoginScreenState extends State<LoginScreen> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
+  final _nameController = TextEditingController();
   bool _isLoading = false;
+  bool _isCreatingAccount = false;
 
   bool get _shouldUseLocalhostForGoogleSignIn =>
       kIsWeb && Uri.base.host == '127.0.0.1';
@@ -39,6 +40,7 @@ class _LoginScreenState extends State<LoginScreen> {
   void dispose() {
     _emailController.dispose();
     _passwordController.dispose();
+    _nameController.dispose();
     super.dispose();
   }
 
@@ -70,6 +72,36 @@ class _LoginScreenState extends State<LoginScreen> {
         _completeAuthNavigation();
       } else {
         _showError('Login failed. Please check your credentials.');
+      }
+    }
+  }
+
+  Future<void> _handleRegister() async {
+    if (_emailController.text.trim().isEmpty) {
+      _showError('Please enter your email');
+      return;
+    }
+
+    final displayName = _nameController.text.trim().isEmpty
+        ? _emailController.text.trim()
+        : _nameController.text.trim();
+
+    setState(() => _isLoading = true);
+
+    final authService = context.read<AuthService>();
+    final success = await authService.register(
+      _emailController.text.trim(),
+      displayName,
+      null,
+    );
+
+    if (mounted) {
+      setState(() => _isLoading = false);
+
+      if (success) {
+        _completeAuthNavigation();
+      } else {
+        _showError('Account creation failed. Please try another email.');
       }
     }
   }
@@ -166,244 +198,69 @@ class _LoginScreenState extends State<LoginScreen> {
     );
   }
 
-  Widget _buildExperiencePanel(
-    BuildContext context, {
-    required bool compact,
-  }) {
-    final theme = Theme.of(context);
-    final panelColor = theme.colorScheme.surface.withValues(alpha: 0.82);
-    final secondaryPanel =
-        theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.26);
-
-    return Container(
-      padding: EdgeInsets.all(compact ? 22 : 28),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(compact ? 28 : 34),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: [
-            panelColor,
-            secondaryPanel,
-          ],
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: theme.shadowColor.withValues(alpha: 0.18),
-            blurRadius: 24,
-            offset: const Offset(0, 12),
-          ),
-        ],
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              GradeFlowEntryMotion(
-                size: compact ? 118 : 152,
-                compact: compact,
-              ),
-              SizedBox(width: compact ? 14 : 20),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _LoginSectionTag(
-                      label: 'Teacher Operating System',
-                    ),
-                    const SizedBox(height: 14),
-                    Text(
-                      GradeFlowProductConfig.appName,
-                      style: (compact
-                              ? theme.textTheme.headlineSmall
-                              : theme.textTheme.headlineMedium)
-                          ?.copyWith(
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 0,
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      'A calm command center for today\'s teaching.',
-                      style: theme.textTheme.bodyLarge?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                        height: 1.5,
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    Text(
-                      'Classes, seating, grades, and live tools stay one motion away.',
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                        height: 1.55,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 22),
-          Wrap(
-            spacing: 10,
-            runSpacing: 10,
-            children: const [
-              _LoginSignalChip(
-                icon: Icons.verified_user_outlined,
-                label: 'Secure workspace',
-              ),
-              _LoginSignalChip(
-                icon: Icons.meeting_room_outlined,
-                label: 'Classroom tools',
-              ),
-              _LoginSignalChip(
-                icon: Icons.auto_graph_rounded,
-                label: 'Live context',
-              ),
-            ],
-          ),
-          const SizedBox(height: 22),
-          Container(
-            padding: const EdgeInsets.all(18),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(24),
-              color: Colors.white.withValues(alpha: 0.03),
-              border: Border.all(
-                color: Colors.white.withValues(alpha: 0.06),
-              ),
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: const [
-                _LoginSectionTag(
-                  label: 'What opens next',
-                ),
-                SizedBox(height: 14),
-                _LoginFeatureTile(
-                  icon: Icons.bolt_outlined,
-                  title: 'Start cleanly',
-                  detail: 'Open into a focused workspace without visual noise.',
-                ),
-                SizedBox(height: 14),
-                _LoginFeatureTile(
-                  icon: Icons.meeting_room_outlined,
-                  title: 'Teach live',
-                  detail:
-                      'Move from class context to seating and tools quickly.',
-                ),
-                SizedBox(height: 14),
-                _LoginFeatureTile(
-                  icon: Icons.insights_outlined,
-                  title: 'Stay aware',
-                  detail: 'Class signals and daily work remain close at hand.',
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
   Widget _buildAccessPanel(
     BuildContext context, {
     required bool compact,
   }) {
     final theme = Theme.of(context);
     final primaryButtonStyle = FilledButton.styleFrom(
-      minimumSize: const Size.fromHeight(52),
+      minimumSize: const Size.fromHeight(54),
+      backgroundColor: const Color(0xFF8B5CF6),
+      foregroundColor: Colors.white,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(18),
+        borderRadius: BorderRadius.circular(19),
+      ),
+      textStyle: theme.textTheme.titleSmall?.copyWith(
+        fontWeight: FontWeight.w800,
+        letterSpacing: 0,
       ),
     );
     final secondaryButtonStyle = OutlinedButton.styleFrom(
-      minimumSize: const Size.fromHeight(48),
+      minimumSize: const Size.fromHeight(50),
+      foregroundColor: const Color(0xFFB8C3FF),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(18),
       ),
       side: BorderSide(
-        color: Colors.white.withValues(alpha: 0.10),
+        color: Colors.white.withValues(alpha: 0.13),
+      ),
+      textStyle: theme.textTheme.titleSmall?.copyWith(
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0,
       ),
     );
 
-    return Container(
-      padding: EdgeInsets.all(compact ? 22 : 26),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(compact ? 28 : 32),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.08)),
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors: [
-            theme.colorScheme.surface.withValues(alpha: 0.90),
-            theme.colorScheme.surfaceContainerHigh.withValues(alpha: 0.82),
-          ],
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: theme.shadowColor.withValues(alpha: 0.18),
-            blurRadius: 24,
-            offset: const Offset(0, 12),
-          ),
-        ],
-      ),
+    return InstructOSAuthCardShell(
+      compact: compact,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: const [
-              _LoginSectionTag(label: 'Secure sign in'),
-              _LoginSectionTag(label: 'Demo-safe preview'),
-            ],
-          ),
-          const SizedBox(height: 14),
           Text(
-            'Enter GradeFlow',
+            InstructOSBranding.productName,
+            textAlign: TextAlign.center,
             style: theme.textTheme.headlineSmall?.copyWith(
-              fontWeight: FontWeight.w800,
+              color: Colors.white,
+              fontWeight: FontWeight.w900,
               letterSpacing: 0,
             ),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: 6),
           Text(
-            'Sign in to open your teaching workspace.',
+            'Teaching, organised.',
+            textAlign: TextAlign.center,
             style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurfaceVariant,
-              height: 1.5,
+              color: const Color(0xFFD7DDF1).withValues(alpha: 0.72),
+              fontWeight: FontWeight.w600,
             ),
           ),
-          const SizedBox(height: 14),
-          Container(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(16),
-              color: theme.colorScheme.primary.withValues(alpha: 0.08),
-              border: Border.all(
-                color: theme.colorScheme.primary.withValues(alpha: 0.16),
-              ),
-            ),
-            child: Row(
-              children: [
-                Icon(
-                  Icons.apartment_rounded,
-                  size: 18,
-                  color: theme.colorScheme.primary,
-                ),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    GradeFlowProductConfig.defaultSchoolName,
-                    style: theme.textTheme.labelLarge?.copyWith(
-                      fontWeight: FontWeight.w700,
-                    ),
-                  ),
-                ),
-              ],
+          SizedBox(height: compact ? 30 : 36),
+          Text(
+            _isCreatingAccount ? 'Create account' : 'Sign in',
+            textAlign: TextAlign.center,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              color: Colors.white.withValues(alpha: 0.94),
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
             ),
           ),
           if (_shouldUseLocalhostForGoogleSignIn) ...[
@@ -412,11 +269,9 @@ class _LoginScreenState extends State<LoginScreen> {
               padding: const EdgeInsets.all(14),
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(18),
-                color: theme.colorScheme.tertiaryContainer.withValues(
-                  alpha: 0.34,
-                ),
+                color: const Color(0xFF142036).withValues(alpha: 0.62),
                 border: Border.all(
-                  color: theme.colorScheme.tertiary.withValues(alpha: 0.28),
+                  color: theme.colorScheme.tertiary.withValues(alpha: 0.30),
                 ),
               ),
               child: Column(
@@ -446,47 +301,60 @@ class _LoginScreenState extends State<LoginScreen> {
               ),
             ),
           ],
-          const SizedBox(height: 20),
+          const SizedBox(height: 22),
           AutofillGroup(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
+                if (_isCreatingAccount) ...[
+                  TextField(
+                    controller: _nameController,
+                    decoration: _portalInputDecoration(
+                      theme,
+                      labelText: 'Name',
+                      prefixIcon: const Icon(Icons.person_outline),
+                    ),
+                    textInputAction: TextInputAction.next,
+                    autofillHints: const [AutofillHints.name],
+                    enabled: !_isLoading,
+                  ),
+                  const SizedBox(height: 12),
+                ],
                 TextField(
                   controller: _emailController,
-                  decoration: InputDecoration(
+                  decoration: _portalInputDecoration(
+                    theme,
                     labelText: 'Email',
                     prefixIcon: const Icon(Icons.email_outlined),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(AppRadius.md),
-                    ),
                   ),
                   keyboardType: TextInputType.emailAddress,
                   textInputAction: TextInputAction.next,
                   autofillHints: const [AutofillHints.username],
                   enabled: !_isLoading,
                 ),
-                const SizedBox(height: 14),
+                const SizedBox(height: 12),
                 TextField(
                   controller: _passwordController,
-                  decoration: InputDecoration(
+                  decoration: _portalInputDecoration(
+                    theme,
                     labelText: 'Password',
                     prefixIcon: const Icon(Icons.lock_outlined),
-                    border: OutlineInputBorder(
-                      borderRadius: BorderRadius.circular(AppRadius.md),
-                    ),
                   ),
                   obscureText: true,
                   textInputAction: TextInputAction.done,
                   autofillHints: const [AutofillHints.password],
                   enabled: !_isLoading,
-                  onSubmitted: (_) => _handleLogin(),
+                  onSubmitted: (_) =>
+                      _isCreatingAccount ? _handleRegister() : _handleLogin(),
                 ),
               ],
             ),
           ),
-          const SizedBox(height: 18),
+          const SizedBox(height: 16),
           FilledButton.icon(
-            onPressed: _isLoading ? null : _handleLogin,
+            onPressed: _isLoading
+                ? null
+                : (_isCreatingAccount ? _handleRegister : _handleLogin),
             style: primaryButtonStyle,
             icon: _isLoading
                 ? const SizedBox(
@@ -495,34 +363,9 @@ class _LoginScreenState extends State<LoginScreen> {
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
                 : const Icon(Icons.arrow_forward_rounded),
-            label: Text(_isLoading ? 'Entering workspace...' : 'Sign In'),
+            label: Text(_isLoading ? 'Opening...' : 'Enter'),
           ),
-          const SizedBox(height: 16),
-          Row(
-            children: [
-              Expanded(
-                child: Divider(
-                  color: Colors.white.withValues(alpha: 0.10),
-                ),
-              ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-                child: Text(
-                  'or continue with',
-                  style: theme.textTheme.labelMedium?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ),
-              Expanded(
-                child: Divider(
-                  color: Colors.white.withValues(alpha: 0.10),
-                ),
-              ),
-            ],
-          ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 14),
           OutlinedButton.icon(
             onPressed: _isLoading ? null : _handleGoogleLogin,
             style: secondaryButtonStyle,
@@ -534,28 +377,65 @@ class _LoginScreenState extends State<LoginScreen> {
             onPressed: _isLoading ? null : _handleDemoLogin,
             style: secondaryButtonStyle,
             icon: const Icon(Icons.preview_outlined),
-            label: const Text('Try Demo Account'),
+            label: const Text('Open demo'),
           ),
-          const SizedBox(height: 14),
-          Container(
-            padding: const EdgeInsets.all(14),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(18),
-              color: Colors.white.withValues(alpha: 0.03),
-              border: Border.all(
-                color: Colors.white.withValues(alpha: 0.06),
-              ),
-            ),
+          const SizedBox(height: 18),
+          TextButton(
+            onPressed: _isLoading
+                ? null
+                : () {
+                    setState(() => _isCreatingAccount = !_isCreatingAccount);
+                  },
             child: Text(
-              'Preview workspace opens a safe sample OS with class tools, seating, and live context.',
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-                height: 1.5,
+              _isCreatingAccount ? 'Sign in' : 'Create account',
+              style: theme.textTheme.labelLarge?.copyWith(
+                color: const Color(0xFFB8C3FF),
+                fontWeight: FontWeight.w700,
               ),
             ),
           ),
         ],
       ),
+    );
+  }
+
+  InputDecoration _portalInputDecoration(
+    ThemeData theme, {
+    required String labelText,
+    required Widget prefixIcon,
+  }) {
+    final borderRadius = BorderRadius.circular(18);
+    return InputDecoration(
+      labelText: labelText,
+      prefixIcon: prefixIcon,
+      filled: true,
+      fillColor: const Color(0xFF070B14).withValues(alpha: 0.46),
+      labelStyle: TextStyle(
+        color: const Color(0xFFD7DDF1).withValues(alpha: 0.78),
+        fontWeight: FontWeight.w600,
+      ),
+      prefixIconColor: const Color(0xFFD7DDF1).withValues(alpha: 0.86),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 18),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: borderRadius,
+        borderSide: BorderSide(
+          color: Colors.white.withValues(alpha: 0.13),
+        ),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: borderRadius,
+        borderSide: const BorderSide(
+          color: Color(0xFF8B5CF6),
+          width: 1.4,
+        ),
+      ),
+      disabledBorder: OutlineInputBorder(
+        borderRadius: borderRadius,
+        borderSide: BorderSide(
+          color: Colors.white.withValues(alpha: 0.07),
+        ),
+      ),
+      border: OutlineInputBorder(borderRadius: borderRadius),
     );
   }
 
@@ -573,176 +453,26 @@ class _LoginScreenState extends State<LoginScreen> {
     }
 
     final size = MediaQuery.sizeOf(context);
-    final wideLayout = size.width >= 980;
     final shortViewport = size.height < 780;
     final edgePadding = shortViewport ? 18.0 : 24.0;
-    final panelGap = wideLayout ? 24.0 : 18.0;
 
     return Scaffold(
-      body: AnimatedPageBackground(
+      body: InstructOSInteractiveAuthBackground(
         child: SafeArea(
           child: Center(
             child: SingleChildScrollView(
               padding: EdgeInsets.all(edgePadding),
               child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 1160),
-                child: wideLayout
-                    ? Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Expanded(
-                            child: _buildExperiencePanel(
-                              context,
-                              compact: false,
-                            ),
-                          ),
-                          SizedBox(width: panelGap),
-                          SizedBox(
-                            width: 404,
-                            child: _buildAccessPanel(
-                              context,
-                              compact: false,
-                            ),
-                          ),
-                        ],
-                      )
-                    : Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          _buildExperiencePanel(context, compact: true),
-                          SizedBox(height: panelGap),
-                          _buildAccessPanel(context, compact: true),
-                        ],
-                      ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _LoginSignalChip extends StatelessWidget {
-  final IconData icon;
-  final String label;
-
-  const _LoginSignalChip({
-    required this.icon,
-    required this.label,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(16),
-        color: Colors.white.withValues(alpha: 0.05),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.10)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(icon, size: 18, color: theme.colorScheme.primary),
-          const SizedBox(width: 8),
-          Text(
-            label,
-            style: theme.textTheme.labelLarge?.copyWith(
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _LoginSectionTag extends StatelessWidget {
-  final String label;
-
-  const _LoginSectionTag({
-    required this.label,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 7),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(999),
-        color: theme.colorScheme.primary.withValues(alpha: 0.10),
-        border: Border.all(
-          color: theme.colorScheme.primary.withValues(alpha: 0.18),
-        ),
-      ),
-      child: Text(
-        label,
-        style: theme.textTheme.labelMedium?.copyWith(
-          color: theme.colorScheme.primary,
-          fontWeight: FontWeight.w700,
-          letterSpacing: 0.3,
-        ),
-      ),
-    );
-  }
-}
-
-class _LoginFeatureTile extends StatelessWidget {
-  final IconData icon;
-  final String title;
-  final String detail;
-
-  const _LoginFeatureTile({
-    required this.icon,
-    required this.title,
-    required this.detail,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Container(
-          width: 42,
-          height: 42,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(14),
-            color: theme.colorScheme.primary.withValues(alpha: 0.14),
-            border: Border.all(
-              color: theme.colorScheme.primary.withValues(alpha: 0.22),
-            ),
-          ),
-          child: Icon(icon, size: 20, color: theme.colorScheme.primary),
-        ),
-        const SizedBox(width: 12),
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                title,
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w800,
+                constraints: const BoxConstraints(maxWidth: 430),
+                child: _buildAccessPanel(
+                  context,
+                  compact: size.width < 560 || shortViewport,
                 ),
               ),
-              const SizedBox(height: 4),
-              Text(
-                detail,
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: theme.colorScheme.onSurfaceVariant,
-                  height: 1.45,
-                ),
-              ),
-            ],
+            ),
           ),
         ),
-      ],
+      ),
     );
   }
 }

--- a/lib/widgets/branding/instructos_auth_card_shell.dart
+++ b/lib/widgets/branding/instructos_auth_card_shell.dart
@@ -1,0 +1,127 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class InstructOSAuthCardShell extends StatelessWidget {
+  final Widget child;
+  final bool compact;
+
+  const InstructOSAuthCardShell({
+    super.key,
+    required this.child,
+    required this.compact,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final radius = BorderRadius.circular(compact ? 30 : 34);
+
+    return ClipRRect(
+      borderRadius: radius,
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: radius,
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.44),
+                blurRadius: 48,
+                offset: const Offset(0, 24),
+              ),
+              BoxShadow(
+                color: theme.colorScheme.primary.withValues(alpha: 0.14),
+                blurRadius: 54,
+              ),
+            ],
+          ),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              borderRadius: radius,
+              border: Border.all(
+                color: Colors.white.withValues(alpha: 0.18),
+              ),
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  const Color(0xFF172033).withValues(alpha: 0.70),
+                  const Color(0xFF0D1322).withValues(alpha: 0.56),
+                  const Color(0xFF111827).withValues(alpha: 0.44),
+                ],
+                stops: const [0.0, 0.54, 1.0],
+              ),
+            ),
+            child: Stack(
+              children: [
+                Positioned(
+                  left: -80,
+                  top: -90,
+                  child: _GlowDisc(
+                    size: compact ? 190 : 240,
+                    color: const Color(0xFFA855F7),
+                    opacity: 0.18,
+                  ),
+                ),
+                Positioned(
+                  right: -90,
+                  bottom: -100,
+                  child: _GlowDisc(
+                    size: compact ? 210 : 260,
+                    color: const Color(0xFF22D3EE),
+                    opacity: 0.14,
+                  ),
+                ),
+                Positioned.fill(
+                  child: IgnorePointer(
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        borderRadius: radius,
+                        border: Border.all(
+                          color: Colors.white.withValues(alpha: 0.055),
+                          width: 6,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+                Padding(
+                  padding: EdgeInsets.all(compact ? 22 : 30),
+                  child: child,
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _GlowDisc extends StatelessWidget {
+  final double size;
+  final Color color;
+  final double opacity;
+
+  const _GlowDisc({
+    required this.size,
+    required this.color,
+    required this.opacity,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ImageFiltered(
+      imageFilter: ImageFilter.blur(sigmaX: 42, sigmaY: 42),
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: color.withValues(alpha: opacity),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/branding/instructos_interactive_auth_background.dart
+++ b/lib/widgets/branding/instructos_interactive_auth_background.dart
@@ -1,0 +1,448 @@
+import 'dart:math' as math;
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+class InstructOSInteractiveAuthBackground extends StatefulWidget {
+  final Widget child;
+
+  const InstructOSInteractiveAuthBackground({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  State<InstructOSInteractiveAuthBackground> createState() =>
+      _InstructOSInteractiveAuthBackgroundState();
+}
+
+class _InstructOSInteractiveAuthBackgroundState
+    extends State<InstructOSInteractiveAuthBackground>
+    with SingleTickerProviderStateMixin {
+  static const Duration _animationDuration = Duration(seconds: 34);
+
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: _animationDuration,
+  )..repeat();
+
+  final ValueNotifier<Offset?> _pointer = ValueNotifier<Offset?>(null);
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final disableAnimations =
+        MediaQuery.maybeOf(context)?.disableAnimations ?? false;
+    if (disableAnimations && _controller.isAnimating) {
+      _controller
+        ..stop()
+        ..value = 0.18;
+    } else if (!disableAnimations && !_controller.isAnimating) {
+      _controller.repeat();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _pointer.dispose();
+    super.dispose();
+  }
+
+  void _trackPointer(PointerEvent event, Size size) {
+    if (size.isEmpty) return;
+    _pointer.value = Offset(
+      (event.localPosition.dx / size.width).clamp(0.0, 1.0),
+      (event.localPosition.dy / size.height).clamp(0.0, 1.0),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final disableAnimations = MediaQuery.disableAnimationsOf(context);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final size = constraints.biggest;
+        final reducedEffects = disableAnimations || size.shortestSide < 560;
+
+        return RepaintBoundary(
+          child: Listener(
+            behavior: HitTestBehavior.translucent,
+            onPointerHover: (event) => _trackPointer(event, size),
+            onPointerMove: (event) => _trackPointer(event, size),
+            onPointerDown: (event) => _trackPointer(event, size),
+            child: ClipRect(
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  const DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [
+                          Color(0xFF050711),
+                          Color(0xFF0A1023),
+                          Color(0xFF090B16),
+                        ],
+                        stops: [0.0, 0.56, 1.0],
+                      ),
+                    ),
+                  ),
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: AnimatedBuilder(
+                        animation: Listenable.merge([_controller, _pointer]),
+                        builder: (context, _) {
+                          return CustomPaint(
+                            painter: _InstructOSAuthBackgroundPainter(
+                              progress: _controller.value,
+                              pointer: _pointer.value,
+                              reducedEffects: reducedEffects,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.centerLeft,
+                            end: Alignment.centerRight,
+                            colors: [
+                              const Color(0xFF050711).withValues(alpha: 0.30),
+                              const Color(0xFF050711).withValues(alpha: 0.04),
+                              const Color(0xFF050711).withValues(alpha: 0.36),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: DecoratedBox(
+                        decoration: BoxDecoration(
+                          gradient: RadialGradient(
+                            center: const Alignment(0, -0.05),
+                            radius: 0.92,
+                            colors: [
+                              Colors.transparent,
+                              const Color(0xFF050711).withValues(alpha: 0.18),
+                              const Color(0xFF050711).withValues(alpha: 0.72),
+                            ],
+                            stops: const [0.0, 0.58, 1.0],
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  widget.child,
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _InstructOSAuthBackgroundPainter extends CustomPainter {
+  final double progress;
+  final Offset? pointer;
+  final bool reducedEffects;
+
+  static final List<_ParticleSeed> _particles = List.generate(56, (index) {
+    final random = math.Random(index * 97 + 13);
+    return _ParticleSeed(
+      position: Offset(random.nextDouble(), random.nextDouble()),
+      radius: 0.7 + random.nextDouble() * 1.9,
+      phase: random.nextDouble() * math.pi * 2,
+      drift: 0.35 + random.nextDouble() * 0.9,
+    );
+  });
+
+  const _InstructOSAuthBackgroundPainter({
+    required this.progress,
+    required this.pointer,
+    required this.reducedEffects,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Offset.zero & size;
+    final pulse = math.sin(progress * math.pi * 2);
+    final pointerPoint = pointer == null
+        ? Offset(
+            size.width * (0.50 + math.sin(progress * math.pi * 2) * 0.06),
+            size.height * (0.48 + math.cos(progress * math.pi * 1.7) * 0.05),
+          )
+        : Offset(pointer!.dx * size.width, pointer!.dy * size.height);
+    final pointerPull = pointer == null ? 0.18 : 1.0;
+
+    _paintSoftLight(canvas, size, pointerPoint, pointerPull);
+    _paintRibbons(canvas, size, pointerPoint, pointerPull);
+    if (!reducedEffects) {
+      _paintParticles(canvas, size, pointerPoint, pointerPull);
+    } else {
+      _paintFallbackDust(canvas, size, pulse);
+    }
+    _paintFineTexture(canvas, rect);
+  }
+
+  void _paintSoftLight(
+    Canvas canvas,
+    Size size,
+    Offset pointerPoint,
+    double pointerPull,
+  ) {
+    final longestSide = math.max(size.width, size.height);
+    final glowPaint = Paint()
+      ..shader = ui.Gradient.radial(
+        pointerPoint,
+        longestSide * (pointer == null ? 0.38 : 0.28),
+        [
+          const Color(0xFF22D3EE).withValues(alpha: 0.16 * pointerPull),
+          const Color(0xFFA855F7).withValues(alpha: 0.07 * pointerPull),
+          Colors.transparent,
+        ],
+        const [0.0, 0.44, 1.0],
+      );
+    canvas.drawCircle(pointerPoint, longestSide * 0.42, glowPaint);
+
+    final cornerPaint = Paint()
+      ..shader = ui.Gradient.radial(
+        Offset(size.width * 0.12, size.height * 0.12),
+        longestSide * 0.44,
+        [
+          const Color(0xFF7C3AED).withValues(alpha: 0.22),
+          Colors.transparent,
+        ],
+      );
+    canvas.drawCircle(
+      Offset(size.width * 0.12, size.height * 0.12),
+      longestSide * 0.44,
+      cornerPaint,
+    );
+  }
+
+  void _paintRibbons(
+    Canvas canvas,
+    Size size,
+    Offset pointerPoint,
+    double pointerPull,
+  ) {
+    _paintRibbon(
+      canvas,
+      size,
+      pointerPoint,
+      pointerPull,
+      phase: 0.00,
+      yBase: 0.27,
+      strokeScale: reducedEffects ? 0.070 : 0.088,
+      blurSigma: reducedEffects ? 24 : 34,
+      colors: [
+        Colors.transparent,
+        const Color(0xFFFF3EA5).withValues(alpha: 0.34),
+        const Color(0xFFA855F7).withValues(alpha: 0.28),
+        const Color(0xFF22D3EE).withValues(alpha: 0.22),
+        Colors.transparent,
+      ],
+    );
+    _paintRibbon(
+      canvas,
+      size,
+      pointerPoint,
+      pointerPull,
+      phase: 0.37,
+      yBase: 0.55,
+      strokeScale: reducedEffects ? 0.052 : 0.066,
+      blurSigma: reducedEffects ? 18 : 26,
+      colors: [
+        Colors.transparent,
+        const Color(0xFF38BDF8).withValues(alpha: 0.18),
+        const Color(0xFF8B5CF6).withValues(alpha: 0.24),
+        const Color(0xFFFF3EA5).withValues(alpha: 0.16),
+        Colors.transparent,
+      ],
+    );
+    _paintRibbon(
+      canvas,
+      size,
+      pointerPoint,
+      pointerPull,
+      phase: 0.72,
+      yBase: 0.76,
+      strokeScale: reducedEffects ? 0.044 : 0.054,
+      blurSigma: reducedEffects ? 16 : 22,
+      colors: [
+        Colors.transparent,
+        const Color(0xFF0EA5E9).withValues(alpha: 0.16),
+        const Color(0xFF22D3EE).withValues(alpha: 0.20),
+        const Color(0xFFA855F7).withValues(alpha: 0.16),
+        Colors.transparent,
+      ],
+    );
+  }
+
+  void _paintRibbon(
+    Canvas canvas,
+    Size size,
+    Offset pointerPoint,
+    double pointerPull, {
+    required double phase,
+    required double yBase,
+    required double strokeScale,
+    required double blurSigma,
+    required List<Color> colors,
+  }) {
+    final theta = (progress + phase) * math.pi * 2;
+    final pointerX = (pointerPoint.dx / size.width).clamp(0.0, 1.0);
+    final pointerY = (pointerPoint.dy / size.height).clamp(0.0, 1.0);
+    final bend = (pointerY - yBase) * size.height * 0.18 * pointerPull;
+    final horizontalBend = (pointerX - 0.5) * size.width * 0.08 * pointerPull;
+    final idleA = math.sin(theta) * size.height * 0.045;
+    final idleB = math.cos(theta * 0.82) * size.height * 0.055;
+
+    final path = Path()
+      ..moveTo(-size.width * 0.16, size.height * yBase + idleA * 0.42)
+      ..cubicTo(
+        size.width * 0.16 + horizontalBend,
+        size.height * (yBase - 0.15) - idleB,
+        size.width * 0.34 + horizontalBend,
+        size.height * (yBase + 0.15) + bend,
+        size.width * 0.52,
+        size.height * yBase - idleA + bend,
+      )
+      ..cubicTo(
+        size.width * 0.70 - horizontalBend,
+        size.height * (yBase - 0.12) + idleB,
+        size.width * 0.88 - horizontalBend,
+        size.height * (yBase + 0.10) - bend * 0.45,
+        size.width * 1.14,
+        size.height * (yBase - 0.04) + idleA * 0.36,
+      );
+
+    final strokeWidth = size.shortestSide * strokeScale;
+    final glowPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = strokeWidth
+      ..shader = ui.Gradient.linear(
+        Offset(0, size.height * yBase),
+        Offset(size.width, size.height * (yBase - 0.04)),
+        colors,
+        const [0.0, 0.18, 0.50, 0.82, 1.0],
+      )
+      ..maskFilter = ui.MaskFilter.blur(ui.BlurStyle.normal, blurSigma);
+
+    final corePaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = math.max(1.2, strokeWidth * 0.12)
+      ..shader = ui.Gradient.linear(
+        Offset(0, size.height * yBase),
+        Offset(size.width, size.height * yBase),
+        [
+          Colors.transparent,
+          Colors.white.withValues(alpha: 0.18),
+          Colors.transparent,
+        ],
+        const [0.0, 0.5, 1.0],
+      )
+      ..maskFilter = ui.MaskFilter.blur(ui.BlurStyle.normal, 6);
+
+    canvas.drawPath(path, glowPaint);
+    canvas.drawPath(path, corePaint);
+  }
+
+  void _paintParticles(
+    Canvas canvas,
+    Size size,
+    Offset pointerPoint,
+    double pointerPull,
+  ) {
+    final paint = Paint()..style = PaintingStyle.fill;
+    final time = progress * math.pi * 2;
+
+    for (final seed in _particles) {
+      final base = Offset(
+        seed.position.dx * size.width,
+        seed.position.dy * size.height,
+      );
+      final drift = Offset(
+        math.sin(time * seed.drift + seed.phase) * 10,
+        math.cos(time * (seed.drift * 0.74) + seed.phase) * 7,
+      );
+      final delta = base - pointerPoint;
+      final distance = delta.distance;
+      final range = size.shortestSide * 0.32;
+      final reaction = (1.0 - (distance / range)).clamp(0.0, 1.0);
+      final pullOffset = distance == 0
+          ? Offset.zero
+          : delta / distance * reaction * 16 * pointerPull;
+      final point = base + drift + pullOffset;
+      final twinkle = 0.55 + math.sin(time * 1.4 + seed.phase) * 0.35;
+      final alpha = (0.12 + reaction * 0.18 + twinkle * 0.08).clamp(0.06, 0.32);
+
+      paint.color = Color.lerp(
+        const Color(0xFFDBEAFE),
+        const Color(0xFF67E8F9),
+        reaction,
+      )!
+          .withValues(alpha: alpha);
+      canvas.drawCircle(point, seed.radius + reaction * 1.6, paint);
+    }
+  }
+
+  void _paintFallbackDust(Canvas canvas, Size size, double pulse) {
+    final paint = Paint()
+      ..style = PaintingStyle.fill
+      ..color = const Color(0xFFBAE6FD).withValues(alpha: 0.08 + pulse * 0.02);
+    for (var i = 0; i < 18; i++) {
+      final seed = _particles[i * 2];
+      canvas.drawCircle(
+        Offset(seed.position.dx * size.width, seed.position.dy * size.height),
+        seed.radius,
+        paint,
+      );
+    }
+  }
+
+  void _paintFineTexture(Canvas canvas, Rect rect) {
+    final linePaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1
+      ..color = Colors.white.withValues(alpha: 0.025);
+
+    for (double y = rect.top + 24; y < rect.bottom; y += 38) {
+      canvas.drawLine(Offset(rect.left, y), Offset(rect.right, y), linePaint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _InstructOSAuthBackgroundPainter oldDelegate) {
+    return oldDelegate.progress != progress ||
+        oldDelegate.pointer != pointer ||
+        oldDelegate.reducedEffects != reducedEffects;
+  }
+}
+
+class _ParticleSeed {
+  final Offset position;
+  final double radius;
+  final double phase;
+  final double drift;
+
+  const _ParticleSeed({
+    required this.position,
+    required this.radius,
+    required this.phase,
+    required this.drift,
+  });
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
     "serve": "^14.2.5"
   },
   "scripts": {
-    "e2e": "playwright test",
+    "e2e": "npm run e2e:smoke && npm run e2e:core",
+    "e2e:smoke": "playwright test e2e/smoke.spec.ts --workers=1",
+    "e2e:routing": "playwright test --config=playwright.gated.config.ts --grep \"@routing\"",
+    "e2e:core": "playwright test --config=playwright.gated.config.ts --grep \"@(routing|core)\"",
+    "e2e:full": "playwright test --config=playwright.gated.config.ts",
+    "e2e:regression": "playwright test --config=playwright.gated.config.ts --grep \"@regression\"",
     "e2e:ui": "playwright test --ui",
     "e2e:report": "playwright show-report"
   }

--- a/playwright.gated.config.ts
+++ b/playwright.gated.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const port = process.env.PORT ?? '7357';
+const baseURL = process.env.BASE_URL ?? `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 90_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  workers: Number(process.env.PLAYWRIGHT_WORKERS ?? '1'),
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['html', { open: 'never' }], ['list']],
+  webServer: {
+    command:
+      process.env.E2E_WEB_SERVER_COMMAND ??
+      `powershell -NoProfile -Command "flutter build web --release; npx.cmd serve build/web -s -l ${port}"`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium',
+      dependencies: ['setup'],
+      testIgnore: /(?:auth\.setup|smoke\.spec)\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'test-results/.auth/demo-user.json',
+      },
+    },
+  ],
+});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: gradeflow
-description: "GradeFlow is a web-first teacher operating system for class workflows, rosters, grading, classroom tools, seating plans, and exports."
+description: "InstructOS is a web-first teacher operating system for class workflows, rosters, grading, classroom tools, seating plans, and exports."
 publish_to: "none"
 version: 1.0.0
 

--- a/test/login_screen_test.dart
+++ b/test/login_screen_test.dart
@@ -40,7 +40,8 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     expect(tester.takeException(), isNull);
-    expect(find.text('Enter GradeFlow'), findsOneWidget);
-    expect(find.text('Try Demo Account'), findsOneWidget);
+    expect(find.text('InstructOS'), findsOneWidget);
+    expect(find.text('Sign in'), findsOneWidget);
+    expect(find.text('Open demo'), findsOneWidget);
   });
 }

--- a/web/index.html
+++ b/web/index.html
@@ -25,7 +25,7 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="GradeFlow">
+  <meta name="apple-mobile-web-app-title" content="InstructOS">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
@@ -35,18 +35,16 @@
   <!-- Set this to your OAuth Web client ID from Google Cloud Console -->
   <meta name="google-signin-client_id" content="851087972500-06hut292tqfb86o9jmfo55tc441de78.apps.googleusercontent.com">
 
-  <title>GradeFlow</title>
+  <title>InstructOS</title>
   <link rel="manifest" href="manifest.json">
   <style>
     :root {
       color-scheme: dark;
       --gf-bg: #050912;
-      --gf-bg-soft: #101a28;
-      --gf-border: rgba(255, 255, 255, 0.1);
+      --gf-bg-soft: #090b16;
       --gf-text: #f5f7fb;
       --gf-muted: rgba(245, 247, 251, 0.72);
-      --gf-accent: #5c88ff;
-      --gf-cyan: #46c6e9;
+      --gf-accent: #8b5cf6;
     }
 
     html,
@@ -55,9 +53,10 @@
       height: 100%;
       margin: 0;
       background:
-        radial-gradient(circle at top right, rgba(92, 136, 255, 0.18), transparent 34%),
-        radial-gradient(circle at bottom left, rgba(70, 198, 233, 0.12), transparent 36%),
-        linear-gradient(140deg, #050912 0%, #071019 54%, var(--gf-bg-soft) 100%);
+        radial-gradient(circle at 24% 38%, rgba(255, 62, 165, 0.16), transparent 32%),
+        radial-gradient(circle at 72% 52%, rgba(34, 211, 238, 0.13), transparent 34%),
+        radial-gradient(circle at 50% 88%, rgba(139, 92, 246, 0.14), transparent 38%),
+        linear-gradient(140deg, #050711 0%, #0a1023 56%, var(--gf-bg-soft) 100%);
       color: var(--gf-text);
     }
 
@@ -77,9 +76,10 @@
       place-items: center;
       padding: 24px;
       background:
-        radial-gradient(circle at top right, rgba(92, 136, 255, 0.20), transparent 34%),
-        radial-gradient(circle at bottom left, rgba(70, 198, 233, 0.14), transparent 40%),
-        linear-gradient(140deg, #050912 0%, #071019 52%, var(--gf-bg-soft) 100%);
+        radial-gradient(circle at 24% 38%, rgba(255, 62, 165, 0.16), transparent 32%),
+        radial-gradient(circle at 72% 52%, rgba(34, 211, 238, 0.13), transparent 34%),
+        radial-gradient(circle at 50% 88%, rgba(139, 92, 246, 0.14), transparent 38%),
+        linear-gradient(140deg, #050711 0%, #0a1023 56%, var(--gf-bg-soft) 100%);
       opacity: 1;
       visibility: visible;
       transition: opacity 360ms ease, visibility 360ms ease;
@@ -94,118 +94,50 @@
 
     .gf-loader-shell {
       position: relative;
-      width: min(100%, 520px);
-      padding: 28px;
-      border-radius: 28px;
-      border: 1px solid var(--gf-border);
-      background: linear-gradient(145deg, rgba(17, 27, 40, 0.9), rgba(11, 18, 28, 0.8));
-      box-shadow:
-        0 24px 64px rgba(0, 0, 0, 0.38),
-        inset 0 1px 0 rgba(255, 255, 255, 0.06);
-      overflow: hidden;
+      width: min(100%, 430px);
       text-align: center;
-    }
-
-    .gf-loader-shell::before {
-      content: "";
-      position: absolute;
-      inset: auto -72px -108px auto;
-      width: 220px;
-      height: 220px;
-      border-radius: 50%;
-      background: radial-gradient(circle, rgba(92, 136, 255, 0.2), transparent 68%);
-      pointer-events: none;
     }
 
     .gf-loader-head {
       display: grid;
       justify-items: center;
-      gap: 12px;
-    }
-
-    .gf-loader-lockup {
-      display: inline-flex;
-      align-items: baseline;
-      gap: 2px;
-      font-size: clamp(1.9rem, 3.5vw, 2.4rem);
-      font-weight: 800;
-      letter-spacing: -0.03em;
-      line-height: 1;
-    }
-
-    .gf-loader-lockup-slash {
-      color: var(--gf-accent);
-    }
-
-    .gf-loader-lockup-os {
-      color: var(--gf-cyan);
+      gap: 6px;
     }
 
     .gf-loader-title {
       margin: 0;
-      font-size: clamp(2rem, 4vw, 2.75rem);
-      font-weight: 800;
-      letter-spacing: -0.04em;
-      line-height: 1.05;
+      font-size: clamp(1.5rem, 4vw, 1.65rem);
+      font-weight: 900;
+      letter-spacing: 0;
+      line-height: 1.1;
     }
 
     .gf-loader-copy {
-      margin: 2px auto 0;
+      margin: 0 auto;
       color: var(--gf-muted);
-      line-height: 1.5;
-      max-width: 34rem;
-      font-size: clamp(0.95rem, 2vw, 1.06rem);
-    }
-
-    .gf-loader-progress {
-      position: relative;
-      height: 3px;
-      margin-top: 24px;
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.14);
-      overflow: hidden;
-    }
-
-    .gf-loader-progress::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      width: 36%;
-      border-radius: inherit;
-      background: linear-gradient(90deg, var(--gf-accent), var(--gf-cyan));
-      box-shadow: 0 0 18px rgba(92, 136, 255, 0.28);
-      animation: gradeflow-loader 1.35s ease-in-out infinite;
-    }
-
-    .gf-loader-status {
-      display: block;
-      margin-top: 18px;
-      color: var(--gf-muted);
-      font-size: 0.9rem;
-      font-weight: 500;
       line-height: 1.4;
+      font-size: 0.95rem;
+      font-weight: 600;
     }
 
-    @keyframes gradeflow-loader {
-      0% {
-        transform: translateX(-115%);
-      }
-      50% {
-        transform: translateX(120%);
-      }
-      100% {
-        transform: translateX(240%);
-      }
+    .gf-loader-dot {
+      width: 7px;
+      height: 7px;
+      margin: 24px auto 0;
+      border-radius: 999px;
+      background: rgba(184, 195, 255, 0.9);
+      box-shadow: 0 0 18px rgba(139, 92, 246, 0.42);
+      animation: instructos-pulse 1.5s ease-in-out infinite alternate;
     }
 
-    @media (max-width: 640px) {
-      .gf-loader-shell {
-        padding: 22px;
-        border-radius: 24px;
+    @keyframes instructos-pulse {
+      from {
+        opacity: 0.36;
+        transform: scale(0.86);
       }
-
-      .gf-loader-head {
-        gap: 10px;
+      to {
+        opacity: 0.88;
+        transform: scale(1);
       }
     }
   </style>
@@ -214,20 +146,15 @@
   <div id="gradeflow-loader" aria-hidden="true">
     <div class="gf-loader-shell">
       <div class="gf-loader-head">
-        <div class="gf-loader-lockup" aria-hidden="true">
-          <span>I</span><span class="gf-loader-lockup-slash">/</span><span class="gf-loader-lockup-os">OS</span>
-        </div>
         <h1 class="gf-loader-title">InstructOS</h1>
-        <p class="gf-loader-copy">One system. Every classroom workflow.</p>
+        <p class="gf-loader-copy">Teaching, organised.</p>
       </div>
-      <div class="gf-loader-progress"></div>
-      <p class="gf-loader-status">Preparing your classroom workspace...</p>
+      <div class="gf-loader-dot"></div>
     </div>
   </div>
   <script>
     (function () {
       const loader = document.getElementById('gradeflow-loader');
-      const status = loader?.querySelector('.gf-loader-status');
       let removed = false;
 
       function removeLoader() {
@@ -256,11 +183,6 @@
         }
       }, 500);
 
-      window.setTimeout(() => {
-        if (!removed && status) {
-          status.textContent = 'Still preparing your classroom workspace...';
-        }
-      }, 45000);
     })();
   </script>
   <script src="flutter_bootstrap.js" async></script>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "GradeFlow",
-    "short_name": "GradeFlow",
+    "name": "InstructOS",
+    "short_name": "InstructOS",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#050912",


### PR DESCRIPTION
## Summary

This PR lands a stabilization checkpoint for the InstructOS relaunch work.

It verifies and commits the current branch state after the recent updates around:

- InstructOS login/auth simplification
- launch and branding alignment
- new branding widgets
- README/product rename updates
- E2E test updates
- start new section carry-forward flow
- class list and export flow touchpoints

## Verification

Passed:

- flutter analyze
- flutter test
- flutter build web --release
- npm run e2e:smoke via npm.cmd

Also manually confirmed:

- release bundle opens locally
- Open demo works
- OS home/dashboard loads
- classes surface is reachable

## Notes

PowerShell blocked npm through npm.ps1, so the same script was run through npm.cmd and passed.

flutter build web --release still reports the existing WebAssembly dry-run warning from the third-party image package, but the release web build succeeds.

## Risk

Low-to-medium.

This is a broad checkpoint commit touching app branding, login, E2E setup, class list/export surfaces, and project metadata. However, the core verification suite is green and the release build succeeds.

## Follow-up

After this branch is safely pushed and reviewed, the next product push should focus on teacher first-10-minutes reliability:

- demo login
- OS home load
- class list
- start new section
- seating
- export
- basic teacher-tool navigation