### PR TITLE
Improve seating and export access confidence

### DIFF
--- a/lib/os/surfaces/class_surface.dart
+++ b/lib/os/surfaces/class_surface.dart
@@ -234,7 +234,7 @@ class _ClassSurfaceState extends State<ClassSurface>
                           icon: Icons.event_seat_rounded,
                           title: 'Seating',
                           description:
-                              'Assign seats and configure room layout.',
+                              'Open the room layout, student placements, and substitute handout tools.',
                           action: 'Open Seating',
                           onTap: () => context.go(
                             AppRoutes.osClassSeating(widget.classId),
@@ -252,7 +252,8 @@ class _ClassSurfaceState extends State<ClassSurface>
                         _ClassToolTab(
                           icon: Icons.picture_as_pdf_rounded,
                           title: 'Export',
-                          description: 'Export grades as PDF or CSV.',
+                          description:
+                              'Preview and download class reports as CSV, XLSX, or PDF.',
                           action: 'Open Export',
                           onTap: () => context.go(
                             AppRoutes.osClassExport(widget.classId),
@@ -1313,24 +1314,22 @@ class _ClassToolTab extends StatelessWidget {
                     ),
                   ),
                   const SizedBox(height: 20),
-                  GestureDetector(
-                    onTap: onTap,
-                    child: Container(
+                  FilledButton(
+                    onPressed: onTap,
+                    style: FilledButton.styleFrom(
+                      backgroundColor: OSColors.blue,
+                      foregroundColor: Colors.white,
                       padding: const EdgeInsets.symmetric(
                         horizontal: 22,
-                        vertical: 11,
+                        vertical: 12,
                       ),
-                      decoration: BoxDecoration(
-                        color: OSColors.blue,
-                        borderRadius: OSRadius.pillBr,
-                      ),
-                      child: Text(
-                        action,
-                        style: const TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w600,
-                          color: Colors.white,
-                        ),
+                      shape: const StadiumBorder(),
+                    ),
+                    child: Text(
+                      action,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
                   ),


### PR DESCRIPTION
## Summary

This PR makes a small teacher first-10-minutes reliability improvement focused on seating and export access confidence.

It improves the class workspace CTAs so they behave more like proper app actions and gives teachers clearer expectations about what each tool provides.

## Changes

- Replaced the custom `GestureDetector` CTA with a real `FilledButton`.
- Improved keyboard/accessibility/automation semantics for the Seating and Export actions.
- Clarified the Seating card copy to mention:
  - room layout
  - placements
  - substitute handout tools
- Clarified the Export card copy to mention:
  - CSV
  - XLSX
  - PDF

## Verification

Passed:

- flutter analyze
- flutter test, 76 tests
- flutter build web --release
- npm.cmd run e2e:smoke, 2 tests
- git diff --check

## Notes

A targeted E2E regression for seating/export access was attempted but removed because it was slow/flaky. Smoke remains fast and unchanged.

## Risk

Low.

Only one file changed:

- lib/os/surfaces/class_surface.dart

This is a focused reliability/accessibility improvement with no redesign and no new feature expansion.

## Follow-up

Continue the teacher first-10-minutes reliability pass with another small slice, likely around:

- class list clarity
- opening a class workspace
- basic navigation between teacher tools
- empty/error state confidence