### PR TITLE
Improve empty and loading state confidence

### DIFF
--- a/lib/screens/class_detail_screen.dart
+++ b/lib/screens/class_detail_screen.dart
@@ -430,12 +430,12 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
       return const WorkspaceScaffold(
         eyebrow: 'Class workspace',
         title: 'Class workspace unavailable',
-        subtitle: 'This class could not be opened in the class workspace.',
+        subtitle: 'This class is not available right now.',
         child: WorkspaceEmptyState(
           icon: Icons.class_outlined,
           title: 'Class not found',
           subtitle:
-              'Return to the OS home surface and open another class workspace to continue.',
+              'Open Classes and choose another class to continue working.',
         ),
       );
     }
@@ -508,9 +508,8 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
       ),
       child: studentService.isLoading || categoryService.isLoading
           ? const WorkspaceLoadingState(
-              title: 'Loading schedule',
-              subtitle:
-                  'Pulling schedule, notes, roster, and class context into view.',
+              title: 'Loading class workspace',
+              subtitle: 'Syncing roster, notes, and schedule for this class.',
             )
           : LayoutBuilder(
               builder: (context, constraints) {

--- a/lib/screens/export_screen.dart
+++ b/lib/screens/export_screen.dart
@@ -2055,7 +2055,22 @@ class _ExportScreenState extends State<ExportScreen> {
         _canExport(studentCount: studentCount, classCount: classCount);
 
     Widget workspace;
-    if (_isCalculating) {
+    if (classItem == null) {
+      workspace = WorkspaceEmptyState(
+        icon: Icons.download_outlined,
+        title: 'Class unavailable',
+        subtitle:
+            'This class is not available anymore. Open Classes and choose another class to export.',
+        actions: [
+          FilledButton.icon(
+            onPressed: () => context.go(AppRoutes.classes),
+            icon: const Icon(Icons.class_outlined),
+            label: const Text('Open classes'),
+            style: WorkspaceButtonStyles.filled(context),
+          ),
+        ],
+      );
+    } else if (_isCalculating) {
       workspace = const WorkspaceLoadingState(
         title: 'Checking report data',
         subtitle: 'Calculating grades and reviewing export readiness.',
@@ -2065,8 +2080,15 @@ class _ExportScreenState extends State<ExportScreen> {
         icon: Icons.group_outlined,
         title: 'No students in this class yet',
         subtitle:
-            'Add students to this roster before generating student or class reports.',
+            'Add students in this class workspace before generating reports.',
         actions: [
+          OutlinedButton.icon(
+            onPressed: () =>
+                context.push(AppRoutes.osClassStudents(widget.classId)),
+            icon: const Icon(Icons.people_alt_outlined),
+            label: const Text('Open roster'),
+            style: WorkspaceButtonStyles.outlined(context),
+          ),
           FilledButton.icon(
             onPressed: _goToClassWorkspace,
             icon: const Icon(Icons.arrow_back_rounded),


### PR DESCRIPTION
﻿## Summary

This PR makes a small teacher first-10-minutes trust improvement focused on empty, loading, and unavailable states.

It keeps the app calmer and more actionable when class or export context is missing, stale, or still loading.

## Changes

- Updated the class workspace unavailable state to use calmer, more teacher-friendly copy.
- Updated the class workspace loading state so it reflects the real loading scope: roster, notes, and schedule.
- Added an explicit class-unavailable state in export with a direct Open classes action.
- Improved the no-students export state with a direct Open roster action.

## Verification

Passed:

- flutter analyze
- flutter test
- flutter build web --release
- npm.cmd run e2e:smoke
- git diff --check

## Notes

An earlier Playwright run showed net::ERR_CONNECTION_REFUSED, but this was diagnosed as a server lifecycle/environment issue during a broader run. The repo smoke flow auto-starts its own server through Playwright webServer, and the smoke command passed when rerun cleanly.

## Risk

Low.

Only two app files were committed:

- lib/screens/class_detail_screen.dart
- lib/screens/export_screen.dart

This is a focused trust/copy/state improvement with no redesign and no new feature expansion.

## Follow-up

Continue the teacher first-10-minutes reliability pass with another small slice after this PR lands.
