### PR TITLE
Connect Ask InstructOS UI to callable service

### DIFF
--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -26,6 +26,7 @@ import 'package:gradeflow/services/communication_service.dart';
 import 'package:gradeflow/services/dashboard_preferences_service.dart';
 import 'package:gradeflow/services/dashboard_weather_service.dart';
 import 'package:gradeflow/services/global_system_shell_service.dart';
+import 'package:gradeflow/services/instructos_assistant_service.dart';
 import 'package:gradeflow/services/teacher_workspace_snapshot_service.dart';
 
 class HomeSurface extends StatefulWidget {
@@ -1927,12 +1928,12 @@ class _AskInstructOSMiniAppContentState
     'Help me with this class',
   ];
 
-  static const String _mockReply =
-      'I can help prepare that. In the next version, I\'ll connect to your class data and planning tools.';
-
+  final InstructOSAssistantService _assistantService =
+      InstructOSAssistantService();
   final TextEditingController _controller = TextEditingController();
   final ScrollController _scrollController = ScrollController();
   final List<_AskInstructOSMessage> _messages = [];
+  bool _isSending = false;
 
   @override
   void dispose() {
@@ -1941,22 +1942,58 @@ class _AskInstructOSMiniAppContentState
     super.dispose();
   }
 
-  void _sendCurrentMessage() {
+  Future<void> _sendCurrentMessage() async {
     final text = _controller.text.trim();
-    if (text.isEmpty) return;
+    if (text.isEmpty || _isSending) return;
+    final conversation = _messages
+        .where((message) => !message.isPending)
+        .map(
+          (message) => InstructOSAssistantMessage(
+            role: message.fromAssistant ? 'assistant' : 'user',
+            content: message.text,
+          ),
+        )
+        .toList(growable: false);
+
     setState(() {
       _messages
         ..add(_AskInstructOSMessage(text: text, fromAssistant: false))
         ..add(const _AskInstructOSMessage(
-          text: _mockReply,
+          text: 'Thinking...',
           fromAssistant: true,
+          isPending: true,
         ));
       _controller.clear();
+      _isSending = true;
+    });
+    _scrollToBottom();
+
+    final reply = await _assistantService.ask(
+      message: text,
+      conversation: conversation,
+    );
+    if (!mounted) return;
+
+    setState(() {
+      final pendingIndex = _messages.lastIndexWhere(
+        (message) => message.isPending,
+      );
+      final replyMessage = _AskInstructOSMessage(
+        text: reply,
+        fromAssistant: true,
+      );
+      if (pendingIndex == -1) {
+        _messages.add(replyMessage);
+      } else {
+        _messages[pendingIndex] = replyMessage;
+      }
+      _isSending = false;
     });
     _scrollToBottom();
   }
 
   void _sendSuggestedPrompt(String prompt) {
+    if (_isSending) return;
     _controller.text = prompt;
     _sendCurrentMessage();
   }
@@ -1996,6 +2033,7 @@ class _AskInstructOSMiniAppContentState
                 ? _AskInstructOSEmptyState(
                     prompts: _suggestedPrompts,
                     onPromptTap: _sendSuggestedPrompt,
+                    enabled: !_isSending,
                   )
                 : ListView.separated(
                     controller: _scrollController,
@@ -2017,11 +2055,13 @@ class _AskInstructOSMiniAppContentState
               prompts: _suggestedPrompts,
               onPromptTap: _sendSuggestedPrompt,
               compact: true,
+              enabled: !_isSending,
             ),
           ),
         _AskInstructOSInputRow(
           controller: _controller,
           onSend: _sendCurrentMessage,
+          isSending: _isSending,
         ),
       ],
     );
@@ -2032,20 +2072,24 @@ class _AskInstructOSMessage {
   const _AskInstructOSMessage({
     required this.text,
     required this.fromAssistant,
+    this.isPending = false,
   });
 
   final String text;
   final bool fromAssistant;
+  final bool isPending;
 }
 
 class _AskInstructOSEmptyState extends StatelessWidget {
   const _AskInstructOSEmptyState({
     required this.prompts,
     required this.onPromptTap,
+    required this.enabled,
   });
 
   final List<String> prompts;
   final ValueChanged<String> onPromptTap;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -2092,7 +2136,11 @@ class _AskInstructOSEmptyState extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 16),
-          _AskPromptChips(prompts: prompts, onPromptTap: onPromptTap),
+          _AskPromptChips(
+            prompts: prompts,
+            onPromptTap: onPromptTap,
+            enabled: enabled,
+          ),
         ],
       ),
     );
@@ -2150,11 +2198,13 @@ class _AskPromptChips extends StatelessWidget {
     required this.prompts,
     required this.onPromptTap,
     this.compact = false,
+    this.enabled = true,
   });
 
   final List<String> prompts;
   final ValueChanged<String> onPromptTap;
   final bool compact;
+  final bool enabled;
 
   @override
   Widget build(BuildContext context) {
@@ -2165,7 +2215,7 @@ class _AskPromptChips extends StatelessWidget {
       children: [
         for (final prompt in prompts)
           OSTouchFeedback(
-            onTap: () => onPromptTap(prompt),
+            onTap: enabled ? () => onPromptTap(prompt) : null,
             borderRadius: OSRadius.pillBr,
             minSize: Size(44, compact ? 30 : 32),
             child: Container(
@@ -2295,10 +2345,12 @@ class _AskInstructOSInputRow extends StatelessWidget {
   const _AskInstructOSInputRow({
     required this.controller,
     required this.onSend,
+    required this.isSending,
   });
 
   final TextEditingController controller;
   final VoidCallback onSend;
+  final bool isSending;
 
   @override
   Widget build(BuildContext context) {
@@ -2343,6 +2395,7 @@ class _AskInstructOSInputRow extends StatelessWidget {
           Expanded(
             child: TextField(
               controller: controller,
+              enabled: !isSending,
               minLines: 1,
               maxLines: 3,
               textInputAction: TextInputAction.send,
@@ -2368,7 +2421,7 @@ class _AskInstructOSInputRow extends StatelessWidget {
           Tooltip(
             message: 'Send',
             child: OSTouchFeedback(
-              onTap: onSend,
+              onTap: isSending ? null : onSend,
               borderRadius: BorderRadius.circular(15),
               minSize: const Size(36, 36),
               child: Container(
@@ -2381,11 +2434,20 @@ class _AskInstructOSInputRow extends StatelessWidget {
                     color: OSColors.indigo.withValues(alpha: 0.26),
                   ),
                 ),
-                child: const Icon(
-                  Icons.arrow_upward_rounded,
-                  size: 18,
-                  color: OSColors.indigo,
-                ),
+                child: isSending
+                    ? const SizedBox(
+                        width: 15,
+                        height: 15,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: OSColors.indigo,
+                        ),
+                      )
+                    : const Icon(
+                        Icons.arrow_upward_rounded,
+                        size: 18,
+                        color: OSColors.indigo,
+                      ),
               ),
             ),
           ),

--- a/lib/services/instructos_assistant_service.dart
+++ b/lib/services/instructos_assistant_service.dart
@@ -1,0 +1,103 @@
+import 'package:cloud_functions/cloud_functions.dart';
+import 'package:flutter/foundation.dart';
+import 'package:gradeflow/services/firebase_service.dart';
+
+typedef InstructOSCallableInvoker = Future<Map<String, dynamic>> Function(
+  Map<String, dynamic> payload,
+);
+
+class InstructOSAssistantMessage {
+  const InstructOSAssistantMessage({
+    required this.role,
+    required this.content,
+  });
+
+  final String role;
+  final String content;
+
+  static const Set<String> allowedRoles = {'user', 'assistant', 'system'};
+
+  Map<String, String> toJson() {
+    final normalizedRole = allowedRoles.contains(role) ? role : 'user';
+    return {
+      'role': normalizedRole,
+      'content': content.trim(),
+    };
+  }
+}
+
+class InstructOSAssistantService {
+  InstructOSAssistantService({
+    FirebaseFunctions? functions,
+    InstructOSCallableInvoker? callableInvoker,
+  })  : _functions = functions,
+        _callableInvoker = callableInvoker;
+
+  static const String fallbackReply =
+      'I can help prepare that. In the next version, I\'ll connect to your class data and planning tools.';
+
+  static const String _functionName = 'askInstructOS';
+  static const int _maxConversationItems = 20;
+
+  final FirebaseFunctions? _functions;
+  final InstructOSCallableInvoker? _callableInvoker;
+
+  Future<String> ask({
+    required String message,
+    List<InstructOSAssistantMessage> conversation = const [],
+    String contextMode = 'general',
+  }) async {
+    final trimmedMessage = message.trim();
+    if (trimmedMessage.isEmpty) {
+      return fallbackReply;
+    }
+
+    final payload = <String, Object?>{
+      'message': trimmedMessage,
+      'conversation': _conversationPayload(conversation),
+      'contextMode':
+          contextMode.trim().isEmpty ? 'general' : contextMode.trim(),
+    };
+
+    try {
+      final data = await _call(payload).timeout(const Duration(seconds: 20));
+      final reply = data['reply'];
+      if (reply is String && reply.trim().isNotEmpty) {
+        return reply.trim();
+      }
+      return fallbackReply;
+    } on FirebaseFunctionsException catch (error) {
+      debugPrint('Ask InstructOS callable failed: ${error.code}');
+      return fallbackReply;
+    } catch (error) {
+      debugPrint('Ask InstructOS unavailable: ${error.runtimeType}');
+      return fallbackReply;
+    }
+  }
+
+  Future<Map<String, dynamic>> _call(Map<String, Object?> payload) async {
+    final invoker = _callableInvoker;
+    if (invoker != null) {
+      return invoker(Map<String, dynamic>.from(payload));
+    }
+
+    if (!FirebaseService.isAvailable) {
+      return const <String, dynamic>{'reply': fallbackReply};
+    }
+
+    final callable =
+        (_functions ?? FirebaseFunctions.instance).httpsCallable(_functionName);
+    final result = await callable.call<Map<String, dynamic>>(payload);
+    return result.data;
+  }
+
+  List<Map<String, String>> _conversationPayload(
+    List<InstructOSAssistantMessage> conversation,
+  ) {
+    return conversation
+        .where((message) => message.content.trim().isNotEmpty)
+        .take(_maxConversationItems)
+        .map((message) => message.toJson())
+        .toList(growable: false);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -177,6 +177,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.4.12"
+  cloud_functions:
+    dependency: "direct main"
+    description:
+      name: cloud_functions
+      sha256: b9ece944fc8c97ac0937cdf45e895f4670213c722ed819581e3d517b43413753
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.6.2"
+  cloud_functions_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_functions_platform_interface
+      sha256: "9720aa2ba715bfb1de6a131c70bbb0fa79329294ec1327fd24ce08004a080dcc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.2"
+  cloud_functions_web:
+    dependency: transitive
+    description:
+      name: cloud_functions_web
+      sha256: "7756b6a6cf16016dc4c8631c88b31b81156b129c40914a84021216a841c0b3d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.11.5"
   code_builder:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   firebase_auth: ^5.5.1
   responsive_framework: ^1.5.1
   icalendar_parser: ^2.1.0
+  cloud_functions: ^5.6.2
 
 dev_dependencies:
   flutter_test:

--- a/test/instructos_assistant_service_test.dart
+++ b/test/instructos_assistant_service_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gradeflow/services/instructos_assistant_service.dart';
+
+void main() {
+  test('ask sends only message conversation and context mode', () async {
+    Map<String, dynamic>? capturedPayload;
+    final service = InstructOSAssistantService(
+      callableInvoker: (payload) async {
+        capturedPayload = payload;
+        return {'reply': 'Backend placeholder reply'};
+      },
+    );
+
+    final reply = await service.ask(
+      message: '  Plan tomorrow  ',
+      conversation: const [
+        InstructOSAssistantMessage(role: 'user', content: 'Hello'),
+        InstructOSAssistantMessage(role: 'assistant', content: 'Hi'),
+        InstructOSAssistantMessage(role: 'unknown', content: 'Normalize me'),
+        InstructOSAssistantMessage(role: 'user', content: '   '),
+      ],
+      contextMode: ' general ',
+    );
+
+    expect(reply, 'Backend placeholder reply');
+    expect(capturedPayload, {
+      'message': 'Plan tomorrow',
+      'conversation': [
+        {'role': 'user', 'content': 'Hello'},
+        {'role': 'assistant', 'content': 'Hi'},
+        {'role': 'user', 'content': 'Normalize me'},
+      ],
+      'contextMode': 'general',
+    });
+  });
+
+  test('ask returns fallback reply when callable fails', () async {
+    final service = InstructOSAssistantService(
+      callableInvoker: (_) async => throw StateError('offline'),
+    );
+
+    final reply = await service.ask(message: 'Create a quick quiz');
+
+    expect(reply, InstructOSAssistantService.fallbackReply);
+  });
+}


### PR DESCRIPTION
Summary
- Adds the Flutter cloud_functions dependency for callable Firebase Functions.
- Adds lib/services/instructos_assistant_service.dart with a small role/content message model and safe ask() wrapper.
- Connects the existing Ask InstructOS mini desktop UI to the askInstructOS callable through the service.
- Adds loading/thinking UI state and prevents duplicate sends while a request is pending.
- Preserves mock fallback behavior when Firebase Functions is unavailable, unauthenticated, times out, or fails.
- Adds lightweight service tests for payload shape and fallback behavior.

Safety boundaries
- No real OpenAI integration is included.
- No API keys or secrets are added or requested.
- No class, student, or planner context is sent.
- No Firestore reads or writes are added.
- No tool calling or voice is included.
- No auth flow, routing, Firestore rules, Firestore indexes, Hosting config, or Firebase Functions behavior is changed.
- Full user messages are not logged by the Flutter service.

Verification results
- flutter pub get: passed.
- flutter analyze: passed.
- flutter test test/instructos_assistant_service_test.dart: passed.
- flutter test: passed, 78 tests.
- flutter build web --release --no-wasm-dry-run: passed.
- Functions checks were not run because no functions/ files changed in this slice.

This still does not include real OpenAI integration, API keys, class/student/planner context, tool calling, or voice.