### PR TITLE
Clean up unsafe OpenAI key setup guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,14 @@
-# OpenAI Configuration (Optional - for AI-powered roster import)
-# Get your API key from https://platform.openai.com/api-keys
-OPENAI_PROXY_API_KEY=your_openai_api_key_here
-OPENAI_PROXY_ENDPOINT=https://api.openai.com/v1/chat/completions
+# Server-side OpenAI configuration only
+#
+# Do not put OpenAI API keys in Flutter/web code, --dart-define, VS Code launch
+# config, or client-side environment variables.
+#
+# Safe architecture:
+# Flutter UI -> service wrapper -> Firebase callable Function -> OpenAI API
+#
+# Store real OpenAI credentials only in Firebase Functions / Google Cloud
+# server-side secret storage. This file is documentation-only and must not
+# contain real secrets.
 
-# Note: These values need to be passed at compile time using --dart-define
-# Example: flutter run --dart-define=OPENAI_PROXY_API_KEY=sk-... --dart-define=OPENAI_PROXY_ENDPOINT=https://...
+# Firebase Functions secret name to create later, outside this repo:
+# OPENAI_API_KEY=<set with Firebase/Google Cloud secret manager, not here>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,10 +36,8 @@
     "Test-Path": true
   },
 
-  // ============================================
-  // 🤖 AI SETUP - SET VIA ENVIRONMENT
-  // ============================================
-  // IMPORTANT: API key is now set via system environment variable, NOT here!
-  // To set up: Set-Item -Path Env:OPENAI_API_KEY -Value "your-key-here"
-  // Never commit actual API keys to version control!
+  // OpenAI/API key safety:
+  // Do not put OpenAI API keys in Flutter/web code, --dart-define, VS Code
+  // launch config, this settings file, or client-side environment variables.
+  // Use Firebase Functions / Google Cloud server-side secrets only.
 }

--- a/AI_COMPREHENSIVE_TESTING_GUIDE.md
+++ b/AI_COMPREHENSIVE_TESTING_GUIDE.md
@@ -9,7 +9,7 @@
 
 ## What You're Testing
 
-**Gradeflow** is a Flutter-based classroom management system that helps teachers manage classes, students, grades, attendance, and interactive classroom activities. The app uses Firebase for data storage and OpenAI API for intelligent file imports.
+**Gradeflow** is a Flutter-based classroom management system that helps teachers manage classes, students, grades, attendance, and interactive classroom activities. The app uses Firebase for data storage. Any future OpenAI API usage must go through Firebase Functions/server-side secrets only.
 
 ### Current Status
 - **Completion**: 95%
@@ -255,7 +255,7 @@ Steps:
   4. Check reminders appear in "This Week's To-Dos"
   
   ERROR HANDLING:
-  1. Try to import with AI when no API key
+  1. Try local or placeholder AI flows without configuring a frontend API key
   2. Should see helpful error message (not crash)
   3. Local features still work without API
   
@@ -489,7 +489,7 @@ App is **PRODUCTION READY** when:
 **If you get quota errors on AI:**
 - [ ] This is expected (free tier limit)
 - [ ] Use local features (they work perfectly)
-- [ ] Or test with paid API key
+- [ ] Do not test with a frontend OpenAI API key
 
 **If data doesn't persist:**
 - [ ] Check browser console (F12) for errors
@@ -523,7 +523,7 @@ App is **PRODUCTION READY** when:
 
 ## Questions Before You Start
 
-1. Should you test with or without a valid OpenAI API key? (Both work, but AI features only function with key)
+1. Should you test the current placeholder/local flows only? Do not configure OpenAI keys in Flutter/web.
 2. Do you need to test on mobile devices or is desktop sufficient?
 3. Should you test extremely large files (10MB+) for import?
 4. Do you need to test concurrent user scenarios?

--- a/AI_INTEGRATION_GUIDE.md
+++ b/AI_INTEGRATION_GUIDE.md
@@ -1,5 +1,10 @@
 # AI Integration Guide
 
+> Safety note: this guide is legacy background for import-related AI ideas.
+> Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code
+> launch config, or client-side environment variables. Future OpenAI calls must
+> go through Firebase Functions/server-side secrets only.
+
 ## Current Status
 
 ### ✅ AI Already Integrated
@@ -19,9 +24,9 @@ The `AiImportService` already has methods for:
 All AI imports follow this pattern:
 
 ```dart
-// 1. Check if AI is configured
+// 1. Check if server-side AI is configured
 if (!OpenAIConfig.isConfigured) {
-  _showError('AI not configured. Set OPENAI_PROXY_ENDPOINT and OPENAI_PROXY_API_KEY.');
+  _showError('AI not configured. Use Firebase Functions/server-side secrets only.');
   return;
 }
 
@@ -128,21 +133,15 @@ if (grid != null && (grid.length > 15 || _hasEmptyCells(grid))) {
 
 ## Configuration
 
-To enable AI, the app needs OpenAI proxy configuration:
+Legacy Flutter-side OpenAI configuration is deprecated and must not be used for
+Flutter web.
 
-### Flutter Run/Build Commands:
-```bash
-flutter run -d chrome --dart-define=OPENAI_PROXY_ENDPOINT=https://your-endpoint --dart-define=OPENAI_PROXY_API_KEY=your-key
+Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code launch
+config, `.vscode/settings.json`, or client-side environment variables.
 
-flutter build web --dart-define=OPENAI_PROXY_ENDPOINT=https://your-endpoint --dart-define=OPENAI_PROXY_API_KEY=your-key
-```
-
-### Environment Setup:
-Or use environment files (requires flutter_dotenv or similar):
-```
-OPENAI_PROXY_ENDPOINT=https://api.openai.com/v1
-OPENAI_PROXY_API_KEY=sk-...
-```
+Future OpenAI setup must use Firebase Functions / Google Cloud server-side
+secret storage. The Flutter app should call a Firebase callable Function, and
+only that server-side function may call the OpenAI API.
 
 ## Testing AI Integration
 
@@ -150,9 +149,9 @@ OPENAI_PROXY_API_KEY=sk-...
    - AI buttons should be hidden (check `OpenAIConfig.isConfigured`)
    - Local parsers work as fallback
    
-2. **With Configuration**:
-   - AI buttons appear in import dialogs
-   - Clicking shows loading state
+2. **With Server-Side Configuration**:
+   - Firebase Functions provide authenticated AI responses
+   - Flutter never receives or stores an OpenAI API key
    - Results display in preview dialog
    - User can confirm or cancel
 

--- a/AI_SETUP_QUICK.md
+++ b/AI_SETUP_QUICK.md
@@ -1,38 +1,19 @@
-# 🤖 AI Setup - Quick Reference Card
+# AI Setup Quick Reference
 
-**Status**: ⚠️ AI Not Configured Yet
+Status: deprecated frontend setup guide.
 
-## ⚡ 2-Minute Setup
+Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code launch
+config, `.vscode/settings.json`, or client-side environment variables.
 
-### Step 1: Get API Key
-👉 https://platform.openai.com/api-keys → Create new key
+Safe architecture:
 
-### Step 2: Add to VS Code
-Open `.vscode/settings.json` and uncomment this section at the bottom:
-
-```json
-"terminal.integrated.env.windows": {
-  "OPENAI_API_KEY": "sk-paste-your-key-here"
-}
+```text
+Flutter UI -> service wrapper -> Firebase callable Function -> OpenAI API
 ```
 
-### Step 3: Run
-Press **F5** → Choose **"Flutter (Chrome) + AI 🤖"**
+OpenAI credentials must live only in Firebase Functions / Google Cloud
+server-side secret storage. The current `askInstructOS` callable is a
+placeholder and does not include real OpenAI integration yet.
 
----
-
-## 📖 Full Guide
-See **SETUP_AI.md** for complete instructions and troubleshooting.
-
-## 🎯 What You Get
-- AI-powered exam score import
-- Smart calendar event detection
-- Automatic data format interpretation
-- Multilingual support
-
-## 💰 Cost
-~$0.01-$0.05 per import (free $5 credit for new accounts)
-
----
-
-**Note**: AI is optional - the app works great without it!
+For this slice, use emulator smoke tests for verification. Do not configure
+frontend OpenAI keys for Flutter web.

--- a/AI_TESTING_PROMPT.md
+++ b/AI_TESTING_PROMPT.md
@@ -16,7 +16,7 @@
 - **State Management**: Provider pattern
 - **Routing**: GoRouter
 - **Backend**: Firebase (Firestore, Authentication, Storage)
-- **AI**: OpenAI API (gpt-4o model) for smart imports and analysis
+- **AI**: Future OpenAI calls must go through Firebase Functions/server-side secrets only
 - **File Support**: CSV, XLSX, DOCX (tables), PDF parsing
 
 ---
@@ -540,7 +540,7 @@
 3. **Quota Errors**:
    - [ ] **Recent Fix**: Better error messages
    - [ ] Distinguish between OpenAI quota and connection issues
-   - [ ] Suggest adding paid API key if quota exceeded
+   - [ ] Suggest backend-only secret setup if real OpenAI integration is added later
    - [ ] Local features work without API
 
 4. **File Errors**:
@@ -617,7 +617,7 @@
 - [ ] All 8 class tools in normal view
 - [ ] All 8 class tools in fullscreen mode
 - [ ] File import/export for students and grades
-- [ ] AI import features (if API key available)
+- [ ] AI import features only through backend-safe test paths
 - [ ] Timetable upload and viewing
 - [ ] Calendar import and reminders
 
@@ -663,12 +663,12 @@ The app is **READY FOR PRODUCTION** when:
 1. Check browser console (F12) for error messages
 2. Check terminal running `flutter run` for Dart errors
 3. Try hard refresh (Ctrl+Shift+R)
-4. Check that OpenAI API key is set (if testing AI features)
+4. Do not configure OpenAI keys in Flutter/web; test backend-only emulator flows for AI placeholders
 5. Document the exact steps to reproduce
 
 **OpenAI API Note**:
-- If you hit quota errors, use local features (they work perfectly without AI)
-- To add paid API key: Contact developer or update environment variable
+- Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code launch config, or client-side environment variables
+- Use local features or backend-only emulator tests until server-side OpenAI integration exists
 
 ---
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -385,12 +385,10 @@ flutter pub get
 
 ### Issue: OpenAI import not working
 
-**Solution**: Ensure API key is provided:
-```powershell
-flutter run -d chrome `
-  --dart-define=OPENAI_PROXY_API_KEY=sk-... `
-  --dart-define=OPENAI_PROXY_ENDPOINT=https://api.openai.com/v1/chat/completions
-```
+**Solution**: Do not configure OpenAI keys in Flutter/web. OpenAI keys must not
+be passed with `--dart-define`, VS Code launch config, or client-side
+environment variables. Future OpenAI calls should go through Firebase
+Functions/server-side secrets only.
 
 ### Issue: PDF Chinese characters not showing
 

--- a/DOCS_INDEX.md
+++ b/DOCS_INDEX.md
@@ -17,9 +17,9 @@
 ### Setup & Configuration
 | Document | Purpose | Status |
 |----------|---------|--------|
-| [AI_SETUP_QUICK.md](AI_SETUP_QUICK.md) | Quick AI setup (2 minutes) | ✅ Complete |
-| [SETUP_AI.md](SETUP_AI.md) | Full AI configuration guide | ✅ Complete |
-| [AI_INTEGRATION_GUIDE.md](AI_INTEGRATION_GUIDE.md) | Technical AI integration details | ✅ Complete |
+| [AI_SETUP_QUICK.md](AI_SETUP_QUICK.md) | Deprecated frontend AI setup warning | Safety note |
+| [SETUP_AI.md](SETUP_AI.md) | Server-side-only AI setup direction | Safety note |
+| [AI_INTEGRATION_GUIDE.md](AI_INTEGRATION_GUIDE.md) | Legacy AI integration details with safety note | Safety note |
 | [.env.example](.env.example) | Environment configuration template | ✅ In place |
 
 ### Security & Deployment
@@ -124,7 +124,7 @@
 ### Development
 ```bash
 flutter run -d chrome  # Run with demo config
-flutter run -d chrome --dart-define=OPENAI_PROXY_API_KEY=sk-...  # With AI
+flutter run -d chrome  # AI keys must not be passed to Flutter/web
 ```
 
 ### Testing

--- a/FINAL_STATUS_REPORT.md
+++ b/FINAL_STATUS_REPORT.md
@@ -13,9 +13,9 @@
 - UI/UX complete and responsive
 - Database schema and indexes ready
 
-⚠️ **AI Integration:** Requires API Key Setup
+⚠️ **AI Integration:** Requires future backend-only secret setup
 - Code implemented and integrated
-- Waiting for valid OpenAI API key
+- Waiting for reviewed Firebase Functions/server-side OpenAI integration
 - All 4 import types wired (Student, Class, Exam, Calendar)
 
 ⚠️ **Authentication:** Partially Tested
@@ -84,7 +84,7 @@
 ### 🔴 Not Yet Tested / Verified
 1. Grade export download in production browsers (Chrome/Firefox/Safari)
 2. Google Sign-In complete flow
-3. AI feature end-to-end (requires API key)
+3. AI feature end-to-end (requires backend-only secret setup)
 4. Performance under load
 5. Error scenarios (network offline, quota exceeded, etc.)
 
@@ -96,7 +96,7 @@
 **Grade: A**
 - No secrets in codebase ✅
 - .env properly gitignored ✅
-- API key validation at startup ✅
+- Historical API key validation existed; frontend key setup is now deprecated ✅
 - SECURITY.md guidelines created ✅
 - Firebase rules reviewed ✅
 - Input validation in place ✅
@@ -144,7 +144,7 @@
 1. [ ] Manual testing of all 30 test cases (MANUAL_TESTING_GUIDE.md)
 2. [ ] Grade export download verified in Chrome/Firefox/Safari
 3. [ ] Google Sign-In flow tested manually
-4. [ ] OpenAI API key set up and AI features tested (if using AI)
+4. [ ] Backend-only OpenAI secret setup and AI features tested (if using AI later)
 
 **Important (Should Have):**
 1. [ ] Performance baseline established
@@ -169,19 +169,15 @@
 - [x] Error handling implemented
 - [x] Loading dialogs implemented
 
-### Configuration Status: ⚠️ Awaiting User
-- API Key: **NOT SET** (needs to be set by user)
-- Endpoint: **SET** (https://api.openai.com/v1)
-- Validation: **IN PLACE** (app checks on startup)
+### Configuration Status
+- Frontend OpenAI key setup: **DEPRECATED**
+- Server-side OpenAI secret setup: **NOT IMPLEMENTED YET**
+- Validation: **IN PLACE** for existing placeholder behavior
 
-### How to Enable AI Features
-```powershell
-# Set environment variable
-Set-Item -Path Env:OPENAI_PROXY_API_KEY -Value "sk-your-key-here"
-
-# Run with AI
-flutter run -d chrome
-```
+### How to Enable AI Features Later
+Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code launch
+config, or client-side environment variables. Add real OpenAI support only via
+Firebase Functions/server-side secrets in a reviewed backend slice.
 
 ### Testing AI Features
 See Section 5 in [MANUAL_TESTING_GUIDE.md](MANUAL_TESTING_GUIDE.md)
@@ -242,10 +238,9 @@ Available at: (staging URL if configured)
 ## Sign-Off & Next Steps
 
 ### Immediate Next Steps
-1. **User to Set Up API Key** (if using AI)
-   - Get key from https://platform.openai.com/api-keys
-   - Set as environment variable
-   - Test AI features
+1. **Backend AI setup** (if using AI later)
+   - Store OpenAI credentials only in Firebase Functions / Google Cloud secrets
+   - Test through backend emulator or deployed backend checks
 
 2. **Run Full Manual Testing**
    - Follow MANUAL_TESTING_GUIDE.md

--- a/MANUAL_TESTING_GUIDE.md
+++ b/MANUAL_TESTING_GUIDE.md
@@ -6,11 +6,8 @@
 
 ### 1. Environment Setup
 ```powershell
-# Set OpenAI API key (if testing AI features)
-Set-Item -Path Env:OPENAI_PROXY_API_KEY -Value "sk-your-actual-key"
-Set-Item -Path Env:OPENAI_PROXY_ENDPOINT -Value "https://api.openai.com/v1"
-
-# Run with AI config
+# Do not configure OpenAI keys in Flutter/web.
+# AI calls must go through Firebase Functions/server-side secrets only.
 flutter run -d chrome
 ```
 

--- a/PROJECT_SUMMARY.md
+++ b/PROJECT_SUMMARY.md
@@ -242,14 +242,11 @@ If you want to customize or extend the app:
 ## 📝 Important Notes
 
 ### Environment Variables (Optional)
-For AI-powered import, set these when running:
-```powershell
-flutter run -d chrome `
-  --dart-define=OPENAI_PROXY_API_KEY=your-key `
-  --dart-define=OPENAI_PROXY_ENDPOINT=https://api.openai.com/v1/chat/completions
-```
+For AI-powered import, do not put OpenAI API keys in Flutter/web code,
+`--dart-define`, VS Code launch config, or client-side environment variables.
+Future OpenAI calls must go through Firebase Functions/server-side secrets only.
 
-**Note**: App works fully without OpenAI. It's only needed for AI-assisted roster parsing.
+**Note**: App works fully without OpenAI.
 
 ### Data Persistence
 - All data is stored in browser localStorage (web)

--- a/README.md
+++ b/README.md
@@ -143,12 +143,13 @@ After that, both machines are looking at the same repo on the desktop. You can s
 
 AI-assisted import analysis is optional. The app still works without it.
 
-Run with:
+Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code launch
+config, or client-side environment variables.
 
-```bash
-flutter run -d chrome \
-  --dart-define=OPENAI_PROXY_API_KEY=sk-your-key-here \
-  --dart-define=OPENAI_PROXY_ENDPOINT=https://api.openai.com/v1/chat/completions
+Future OpenAI integration must use Firebase Functions/server-side secrets only:
+
+```text
+Flutter UI -> service wrapper -> Firebase callable Function -> OpenAI API
 ```
 
 ### Firebase

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,83 +1,60 @@
 # Security Guidelines - Gradeflow
 
-**Last Updated:** January 16, 2026
+Last updated: May 15, 2026
 
-## Critical: API Key Management
+## Critical: OpenAI API Key Management
 
-### ⚠️ API Key Exposure History
-A production OpenAI API key was accidentally committed to git history on:
-- Commits: `a6de36f`, `a272c14`
-- Status: **REVOKED AND REGENERATED**
-- Action: If you have access to git history, assume that key is compromised
+OpenAI API keys must never be exposed to Flutter/web clients.
 
-### ✅ Current Security Status
-- API keys are **NOT** stored in version control
-- Environment variables are used for secrets
-- `.env` file is in `.gitignore`
-- Settings JSON contains no actual keys
+Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code launch
+config, `.vscode/settings.json`, or client-side environment variables.
 
-### How to Set Up Secrets Safely
+Use this architecture only:
 
-#### Option 1: PowerShell Environment Variable (Development)
-```powershell
-Set-Item -Path Env:OPENAI_PROXY_API_KEY -Value "sk-your-key-here"
-Set-Item -Path Env:OPENAI_PROXY_ENDPOINT -Value "https://api.openai.com/v1"
-flutter run -d chrome
+```text
+Flutter UI -> service wrapper -> Firebase callable Function -> OpenAI API
 ```
 
-#### Option 2: VS Code Launch Configuration
-Edit `.vscode/launch.json` and add to the `Flutter (Chrome) + AI 🤖` configuration:
-```json
-"env": {
-  "OPENAI_PROXY_API_KEY": "${env:OPENAI_PROXY_API_KEY}",
-  "OPENAI_PROXY_ENDPOINT": "https://api.openai.com/v1"
-}
-```
+Store OpenAI credentials in Firebase Functions / Google Cloud server-side secret
+storage and read them only from backend function runtime code.
 
-#### Option 3: Firebase Cloud Build (Production)
-Store secrets in Google Cloud Secret Manager and inject them during build.
+## API Key Exposure History
 
-### Secrets to Rotate/Check
+A production OpenAI API key was previously committed to git history. That key
+was revoked and should be treated as permanently compromised.
 
-- [ ] OpenAI API Key - **ROTATE NOW**
-- [ ] Firebase Service Account Key
-- [ ] Google Cloud API Keys  
-- [ ] GitHub Personal Access Token (if used)
+If you have access to old history, assume any historical OpenAI key is unsafe.
+Do not reuse it.
 
-### Audit Checklist
+## Current Security Status
 
-- [ ] Remove all API keys from `.vscode/settings.json`
-- [ ] Check `.env` file is in `.gitignore`
-- [ ] Verify no keys in git history (search for `sk-`, `AIza`, `firebase_key`)
-- [ ] Enable git hooks to prevent future commits of secrets (use `gitleaks` or similar)
-- [ ] Rotate any keys that were exposed
+- API keys are not stored in version control.
+- `.env` is ignored by git.
+- `.vscode/settings.json` contains no OpenAI keys.
+- Future OpenAI integration must be server-side only.
 
-### Best Practices Going Forward
+## Best Practices
 
-1. **Never commit secrets** - Use environment variables
-2. **Use .env files locally** - Copy `.env.example` to `.env`, add your keys
-3. **Add to .gitignore** - Ensure `.env` is ignored
-4. **Use secret managers** - Firebase, AWS Secrets Manager, Google Cloud Secret Manager for production
-5. **Rotate regularly** - Change API keys every 90 days
-6. **Monitor usage** - Check OpenAI dashboard for unexpected activity
+1. Never commit secrets.
+2. Never expose OpenAI keys to Flutter web.
+3. Never pass OpenAI keys with `--dart-define`.
+4. Never put OpenAI keys in VS Code settings or launch configs.
+5. Use Firebase Functions / Google Cloud Secret Manager for OpenAI credentials.
+6. Rotate any key after suspected exposure.
+7. Monitor OpenAI usage after any suspected leak.
 
-### Detection
+## Audit Checklist
 
-To find any remaining secrets in the codebase:
-```bash
-git log --all -p | grep -i "sk-\|AIza\|secret\|api.key" | head -20
-```
+- [ ] Search tracked files for `sk-`, `OPENAI_API_KEY`, and related names.
+- [ ] Confirm `.vscode/settings.json` has no OpenAI key values.
+- [ ] Confirm docs do not instruct frontend key setup.
+- [ ] Confirm any future backend OpenAI key is stored in server-side secret storage.
+- [ ] Use tools such as `gitleaks` for deeper history scanning when needed.
 
-Or use a tool like `gitleaks`:
-```bash
-gitleaks detect --source . -v
-```
+## If You Suspect a Key Leak
 
----
-
-**If you suspect a key leak:**
-1. Immediately revoke the key in the service provider
-2. Generate a new key
-3. Update environment variables
-4. Redeploy
-5. Check logs for unauthorized usage
+1. Immediately revoke the key in the service provider dashboard.
+2. Generate a new key only if still needed.
+3. Store the new key server-side only.
+4. Check logs and billing dashboards for unauthorized usage.
+5. Audit git history and any published artifacts.

--- a/SECURITY_INCIDENT_RESPONSE.md
+++ b/SECURITY_INCIDENT_RESPONSE.md
@@ -1,182 +1,49 @@
-# 🔴 SECURITY INCIDENT - API KEY EXPOSURE
-
-## Date
-January 13, 2026
+# Security Incident Response - API Key Exposure
 
 ## Incident Summary
 
-**Status**: ✅ **RESOLVED**
+A production OpenAI API key was previously exposed in repository history. The
+key was revoked and must be treated as permanently compromised.
 
-An OpenAI API key (`sk-proj-n-20Gp...awA`) owned by Stuart Gaston was exposed in the GitHub repository and has been **revoked by OpenAI**.
+Do not print, reuse, or redistribute any historical secret value. If a report
+needs to reference a key, redact it and show only the file or variable name plus
+at most the first and last three characters.
 
----
+## Current Safe Architecture
 
-## What Happened
-
-### Discovery
-- Received email from OpenAI notifying of a leaked API key
-- Key was associated with organization "user-jorkxdqpv0zd4ftzg1qbqqqg"
-- OpenAI automatically disabled the key with immediate effect
-
-### Root Cause
-- API key was stored in `.vscode/settings.json` in plaintext
-- This file was committed to GitHub history
-- **Lesson**: Never commit secrets to version control, even in local configuration files
-
----
-
-## Actions Taken ✅
-
-### 1. **Removed API Key from Repository**
-- **File**: `.vscode/settings.json`
-- **Action**: Replaced actual key with safe comment
-- **Commit**: a6de36f - "SECURITY: Remove exposed OpenAI API key from settings.json"
-
-### 2. **Rewritten Git History**
-- Used `git filter-branch` to remove key from all historical commits
-- Rewritten commits: 10 commits affected
-- Key now shows as "REDACTED" in entire repository history
-- **Force Push**: Updated GitHub with cleaned history (main + 4e3c376...a272c14)
-
-### 3. **Updated .gitignore**
-- Confirmed `.env` and sensitive files are in `.gitignore`
-- Added documentation in `.vscode/settings.json` to prevent future incidents
-
----
-
-## How to Get a New API Key
-
-### Step 1: Go to OpenAI API Keys Page
-1. Visit: https://platform.openai.com/api/keys
-2. Sign in with your OpenAI account (gastonstuart@googlemail.com)
-
-### Step 2: Create New API Key
-1. Click "+ Create new secret key"
-2. Name it: `Gradeflow` (or similar)
-3. **Copy the key immediately** - you won't see it again!
-4. Starts with: `sk-proj-...`
-
-### Step 3: Set in Your Environment
-**Windows (PowerShell):**
-```powershell
-[Environment]::SetEnvironmentVariable("OPENAI_API_KEY", "sk-proj-YOUR-NEW-KEY-HERE", "User")
+```text
+Flutter UI -> service wrapper -> Firebase callable Function -> OpenAI API
 ```
 
-Then restart PowerShell/VS Code for changes to take effect.
+The Flutter/web app must never read or receive an OpenAI API key. Only a
+server-side Firebase Function may read the secret and call OpenAI.
 
-**Linux/macOS (Bash):**
-```bash
-export OPENAI_API_KEY="sk-proj-YOUR-NEW-KEY-HERE"
-```
+## Hard Rules
 
-Add to `~/.bashrc` or `~/.zshrc` for persistence.
+- Do not put OpenAI API keys in Flutter/web code.
+- Do not pass OpenAI API keys with `--dart-define`.
+- Do not put OpenAI API keys in VS Code launch config or `.vscode/settings.json`.
+- Do not put OpenAI API keys in client-side environment variables.
+- Do not commit `.env` files containing real secrets.
+- Do not print secrets during verification.
 
-### Step 4: Verify Setup
-Run this command to confirm the key is set:
-```bash
-echo $OPENAI_API_KEY
-```
+## If a Key Is Exposed
 
-Should print your key (starting with `sk-proj-`)
+1. Revoke the key immediately in the provider dashboard.
+2. Generate a replacement only if still needed.
+3. Store the replacement only in Firebase Functions / Google Cloud server-side
+   secret storage.
+4. Audit tracked files and git history for additional exposures.
+5. Check provider billing and usage logs for unauthorized activity.
+6. Document the incident using redacted key references only.
 
----
+## Safe Verification
 
-## How the App Uses the Key
+Verify setup through backend-only emulator tests or deployed backend checks that
+do not echo secrets. For Ask InstructOS, use the Firebase callable emulator
+smoke tests until a reviewed server-side OpenAI integration is added.
 
-The Gradeflow app reads the key from **environment variables**, not from files:
+## Notes
 
-```dart
-// In lib/openai/openai_config.dart
-final apiKey = Platform.environment['OPENAI_PROXY_API_KEY'];
-```
-
-**When running with Flutter:**
-```bash
-flutter run -d chrome \
-  --dart-define=OPENAI_PROXY_API_KEY=$OPENAI_API_KEY \
-  --dart-define=OPENAI_PROXY_ENDPOINT=https://api.openai.com/v1
-```
-
-**For Firebase deployment:**
-- The API key is **NOT** stored in Firebase config
-- Users must set it locally on their machine
-- The web app will use their environment variable
-
----
-
-## Security Best Practices Going Forward
-
-### ✅ DO:
-- ✅ Store API keys in **environment variables** only
-- ✅ Use `.env` files (keep these in `.gitignore`)
-- ✅ Use system environment variables (`Set-Item -Path Env:...`)
-- ✅ Store secrets in `.gitignore`d files
-- ✅ Use CI/CD secrets management (GitHub Secrets, Firebase Secret Manager)
-- ✅ Rotate keys after any suspected exposure
-
-### ❌ DON'T:
-- ❌ Never commit API keys to git (even "for testing")
-- ❌ Never hardcode keys in source code
-- ❌ Never commit `.env` files with real keys
-- ❌ Never share keys via email/chat unencrypted
-- ❌ Never use the same key across multiple projects
-
----
-
-## Files Affected
-
-| File | Action | Current State |
-|------|--------|---------------|
-| `.vscode/settings.json` | API key removed | Safe - contains only comment |
-| `.gitignore` | Verified | Already includes `.env` |
-| Git History | Rewritten | Key removed from all commits |
-| GitHub | Force pushed | History cleaned |
-
----
-
-## Verification Checklist
-
-- [x] API key removed from `.vscode/settings.json`
-- [x] Git history rewritten (key redacted from all commits)
-- [x] GitHub repository updated with force push
-- [x] Old key disabled by OpenAI (automatic)
-- [x] New API key created and set in environment
-- [x] `.gitignore` verified for sensitive files
-- [x] Security documentation created
-
----
-
-## Next Steps
-
-1. **Create New OpenAI API Key** (see above)
-2. **Set Environment Variable** with your new key
-3. **Test the app** to confirm AI features work:
-   ```bash
-   flutter run -d chrome \
-     --dart-define=OPENAI_PROXY_API_KEY=$OPENAI_API_KEY \
-     --dart-define=OPENAI_PROXY_ENDPOINT=https://api.openai.com/v1
-   ```
-4. **Monitor for unauthorized usage** in OpenAI billing dashboard
-5. **Review other projects** - check if this key was used elsewhere
-
----
-
-## Important Notes
-
-- **This key is now useless**: OpenAI disabled it automatically
-- **No immediate action required on deployed app**: The web app doesn't store the key in code
-- **Create new key ASAP**: So you can continue using AI features locally
-- **Don't reuse the old key**: It's permanently disabled
-
----
-
-## Questions?
-
-- **OpenAI Security**: https://platform.openai.com/docs/guides/production-best-practices
-- **Environment Variables in Flutter**: https://flutter.dev/docs/development/environment-vars
-- **Git Filter-branch**: https://git-scm.com/docs/git-filter-branch
-
----
-
-**Status**: Incident resolved. Repository is now secure.
-
+The current Ask InstructOS callable is a placeholder. No real OpenAI integration
+is added by this cleanup.

--- a/SESSION_SUMMARY.md
+++ b/SESSION_SUMMARY.md
@@ -137,11 +137,8 @@ Created comprehensive documentation:
 - `analyzeTimetableFromRows()` - Timetable interpretation
 
 **Configuration Required**:
-```bash
-flutter run -d chrome \
-  --dart-define=OPENAI_PROXY_ENDPOINT=https://api.openai.com/v1 \
-  --dart-define=OPENAI_PROXY_API_KEY=sk-...
-```
+Do not configure OpenAI keys in Flutter/web. Future OpenAI calls must use
+Firebase Functions/server-side secrets only.
 
 **Implementation Priority**:
 1. Student import AI (HIGH) - Most frequently used
@@ -252,16 +249,9 @@ flutter run -d chrome \
    - Only needed for complex/non-standard formats
 
 ### Configuration (Optional for AI)
-```bash
-# Set environment variables
-OPENAI_PROXY_ENDPOINT=https://api.openai.com/v1
-OPENAI_PROXY_API_KEY=sk-your-key-here
-
-# Or pass as build flags
-flutter run -d chrome \
-  --dart-define=OPENAI_PROXY_ENDPOINT=$OPENAI_PROXY_ENDPOINT \
-  --dart-define=OPENAI_PROXY_API_KEY=$OPENAI_PROXY_API_KEY
-```
+Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code launch
+config, or client-side environment variables. Future OpenAI integration must use
+Firebase Functions/server-side secrets only.
 
 ---
 

--- a/SETUP_AI.md
+++ b/SETUP_AI.md
@@ -1,110 +1,33 @@
-# 🚀 Quick Start: Enable AI Features
+# AI Setup
 
-## Super Easy Setup (2 Options!)
+Status: deprecated frontend setup guide.
 
-### ⭐ EASIEST: Option 1 - VS Code Settings (Recommended)
+Older versions of this document described putting OpenAI keys in VS Code,
+terminal environment variables, `.env`, or Flutter `--dart-define` values.
+That is unsafe for Flutter web because those values can be exposed to the
+client bundle or local tooling.
 
-1. **Get your OpenAI API key**:
-   - Go to https://platform.openai.com/api-keys
-   - Sign in or create account
-   - Click "Create new secret key"
-   - Copy the key (starts with `sk-...`)
+Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code launch
+config, `.vscode/settings.json`, or client-side environment variables.
 
-2. **Add to VS Code settings**:
-   - Open `.vscode/settings.json` (it's already in your workspace)
-   - Find the commented section at the bottom
-   - Uncomment and replace `sk-your-actual-api-key-here` with your real key:
-   ```json
-   "terminal.integrated.env.windows": {
-     "OPENAI_API_KEY": "sk-proj-abc123xyz..."
-   }
-   ```
-   - Save the file
+## Safe Direction
 
-3. **Run with AI**:
-   - Press **F5**
-   - Select **"Flutter (Chrome) + AI 🤖"** from dropdown
-   - Done! AI features now work
+Use this architecture only:
 
-### 🔒 Option 2 - .env File (More Secure)
+```text
+Flutter UI
+  -> service wrapper
+  -> Firebase callable Function
+  -> OpenAI API called server-side only
+```
 
-1. **Get your API key** (same as Option 1)
+When real OpenAI integration is added later:
 
-2. **Edit `.env` file**:
-   - Open `.env` in the project root
-   - Replace `your_openai_api_key_here` with your real key
-   - Save
+1. Store the OpenAI API key as a Firebase Functions / Google Cloud secret.
+2. Read the secret only inside the Firebase Function runtime.
+3. Require Firebase Auth before making real AI calls.
+4. Keep Flutter/web responsible only for sending validated request payloads and
+   rendering responses.
 
-3. **Set Windows environment variable**:
-   ```powershell
-   # In PowerShell (run as yourself, not admin):
-   [Environment]::SetEnvironmentVariable("OPENAI_API_KEY", "sk-your-key-here", "User")
-   ```
-
-4. **Restart VS Code** completely (close all windows)
-
-5. **Run**: Press F5 → Select "Flutter (Chrome) + AI 🤖"
-
----
-
-## 🎯 Using AI Features
-
-Once running with the AI config, you'll see AI options in:
-
-### 📊 Exam Score Import ✅ (Already Integrated)
-- Upload exam file
-- Click "Try AI" if format unclear
-- AI extracts scores automatically
-
-### 📅 Calendar Import ✅ (Already Integrated)
-- Import schedule file  
-- "Try AI" appears on parsing errors
-- AI interprets calendar events
-
----
-
-## ✅ How to Verify It's Working
-
-**AI is Enabled when**:
-- Launch dropdown shows: `Flutter (Chrome) + AI 🤖`
-- Console shows OpenAI configuration loaded
-- Import screens show "Try AI" buttons
-
-**AI is NOT enabled when**:
-- Using regular "Flutter (Chrome)" config
-- No AI buttons in import dialogs
-- That's fine! App works great without AI
-
----
-
-## 💰 Costs
-
-- **Pay per use**: ~$0.01-$0.05 per import
-- **Free tier**: $5 credit for new OpenAI accounts
-- **Optional**: App has smart local parsers that work without AI
-
----
-
-## 🔧 Troubleshooting
-
-### "AI is not configured" error
-1. Check you selected the AI launch config (with 🤖 emoji)
-2. Verify API key is in `.vscode/settings.json` or environment variable
-3. Restart VS Code completely
-4. Check OpenAI account has credits: https://platform.openai.com/usage
-
-### Environment variable not loading
-**Quick fix**:
-Just use Option 1 (VS Code settings) - it's simpler!
-
----
-
-## 🔐 Security
-
-✅ `.env` file is gitignored (safe)  
-✅ API key only on your machine  
-⚠️ **Don't** commit API keys to git  
-⚠️ **Don't** share your key  
-
-**Best Practice**: Use Option 1 (settings.json) for local dev, or set Windows User environment variable for better security.
-
+The current `askInstructOS` callable is intentionally a placeholder. No real
+OpenAI integration is configured by this document.

--- a/START_HERE_AI.md
+++ b/START_HERE_AI.md
@@ -1,138 +1,22 @@
-# ✨ AI Features - Start Here
+# AI Setup Start Here
 
-## 🎯 What's Set Up
+Status: deprecated frontend setup guide.
 
-Your VS Code workspace is **ready for AI integration**! Here's what's configured:
+Do not follow older instructions that ask you to paste OpenAI keys into VS Code,
+`.env`, terminal environment variables for Flutter, or `--dart-define`.
 
-### ✅ Launch Configurations
-- **Flutter (Chrome)** - Normal mode (no AI)
-- **Flutter (Chrome) + AI 🤖** - With AI features enabled
+Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code launch
+config, `.vscode/settings.json`, or client-side environment variables.
 
-### ✅ Files Created
-- `.vscode/launch.json` - Run configurations
-- `.vscode/settings.json` - Environment setup (you'll edit this)
-- `.vscode/tasks.json` - Helper tasks
-- `.env` - Alternative configuration file
-- `load-env.ps1` - PowerShell helper script
-- `test-ai-config.ps1` - Test if AI is working
+## Current Safe Architecture
 
-### ✅ Documentation
-- `AI_SETUP_QUICK.md` ⭐ **Quick 2-minute guide**
-- `SETUP_AI.md` - Complete setup guide
-- `AI_INTEGRATION_GUIDE.md` - Technical details
-
----
-
-## 🚀 Quick Start (Choose One Method)
-
-### Method 1: VS Code Settings (Easiest!)
-
-1. **Get OpenAI API Key**:
-   - Visit: https://platform.openai.com/api-keys
-   - Create account if needed
-   - Click "Create new secret key"
-   - Copy the entire key (starts with `sk-`)
-
-2. **Add to VS Code**:
-   - Open `.vscode/settings.json`
-   - Scroll to the bottom
-   - Find the commented AI section
-   - Uncomment and paste your key:
-   ```json
-   "terminal.integrated.env.windows": {
-     "OPENAI_API_KEY": "sk-your-actual-key-here"
-   }
-   ```
-   - **Save the file** (Ctrl+S)
-
-3. **Restart VS Code** completely:
-   - Close all VS Code windows
-   - Reopen your project
-
-4. **Run with AI**:
-   - Press **F5**
-   - In the dropdown, select: **"Flutter (Chrome) + AI 🤖"**
-   - Click the green play button
-
-5. **Test it works**:
-   ```powershell
-   # In VS Code terminal:
-   .\test-ai-config.ps1
-   ```
-
-### Method 2: Windows Environment Variable
-
-```powershell
-# In PowerShell (not as admin):
-[Environment]::SetEnvironmentVariable("OPENAI_API_KEY", "sk-your-key", "User")
-
-# Restart VS Code completely
-# Then press F5 and select the AI config
+```text
+Flutter UI -> service wrapper -> Firebase callable Function -> OpenAI API
 ```
 
----
+OpenAI API keys must stay server-side in Firebase Functions / Google Cloud
+secret storage. The current Ask InstructOS backend is a placeholder callable and
+does not call OpenAI yet.
 
-## 🎮 How to Use AI Features
-
-Once running with the AI configuration:
-
-### In Exam Input Screen
-1. Upload exam scores (Excel/CSV/PDF)
-2. If format is unclear → Click **"Try AI"** button
-3. AI analyzes and extracts scores automatically
-
-### In Calendar/Schedule Import
-1. Import calendar file
-2. On parsing errors → Click **"Try AI"**
-3. AI interprets dates and events
-
----
-
-## 🔍 Verify It's Working
-
-### ✅ AI is Enabled:
-- Launch config dropdown shows: `Flutter (Chrome) + AI 🤖`
-- Import screens show "Try AI" buttons
-- No "AI not configured" error messages
-
-### ❌ AI is Disabled:
-- Using regular "Flutter (Chrome)" config
-- No AI buttons visible
-- This is fine! App works perfectly without AI
-
----
-
-## 💡 Tips
-
-- **Cost**: ~$0.01-$0.05 per AI import (free $5 credit for new accounts)
-- **Optional**: AI is a helper, not required - local parsers work great
-- **Security**: Your API key stays on your machine only
-- **Monitor**: Check usage at https://platform.openai.com/usage
-
----
-
-## 🆘 Troubleshooting
-
-### "AI is not configured" error
-1. Did you select the **AI launch config** (with 🤖)?
-2. Did you **restart VS Code** after adding the key?
-3. Run the test script: `.\test-ai-config.ps1`
-
-### Test script fails
-1. Check the key is pasted correctly in settings.json
-2. Make sure there are no extra spaces
-3. Verify the JSON syntax is correct (no missing commas)
-
-### Still not working?
-See the full guide: **SETUP_AI.md**
-
----
-
-## 📚 Next Steps
-
-1. ✅ Set up your API key (see above)
-2. ✅ Run with AI config
-3. ✅ Test with an exam score import
-4. 📖 Read `AI_INTEGRATION_GUIDE.md` for advanced usage
-
-**That's it!** You're all set up for AI-powered imports 🎉
+Use local Firebase emulator smoke tests to verify callable behavior. Add real
+OpenAI integration only in a later reviewed backend slice.

--- a/TESTING_START_HERE.md
+++ b/TESTING_START_HERE.md
@@ -244,15 +244,14 @@ flutter build apk
 
 **Run Locally**:
 ```bash
-flutter run -d chrome --dart-define=OPENAI_PROXY_API_KEY=$env:OPENAI_API_KEY
+flutter run -d chrome
 ```
 
-### Environment Variables
-```
-OPENAI_PROXY_API_KEY=[your OpenAI API key]
-OPENAI_PROXY_ENDPOINT=https://api.openai.com/v1
-GOOGLE_CLIENT_ID=[from Firebase]
-```
+### OpenAI Secrets
+
+Do not put OpenAI API keys in Flutter/web code, `--dart-define`, VS Code launch
+config, or client-side environment variables. Future OpenAI calls must go
+through Firebase Functions/server-side secrets only.
 
 ---
 

--- a/YOUR_ACTION_PLAN.md
+++ b/YOUR_ACTION_PLAN.md
@@ -7,14 +7,8 @@
 
 ### Hour 1: Setup (15 min)
 ```powershell
-# 1. Get your OpenAI API key
-# Go to: https://platform.openai.com/api-keys
-# Create new key, copy it
-
-# 2. Set the environment variable
-Set-Item -Path Env:OPENAI_PROXY_API_KEY -Value "sk-paste-your-key-here"
-
-# 3. Run the app with AI
+# Do not configure OpenAI keys in Flutter/web.
+# OpenAI calls must use Firebase Functions/server-side secrets only.
 cd c:\Dev\Gradeflow
 flutter run -d chrome
 ```
@@ -238,10 +232,12 @@ After deployment, verify:
 **You've got this! 🎉**
 
 Everything is ready. You just need to:
-1. Get your OpenAI API key (if using AI)
-2. Run through the manual tests (1-2 hours)
-3. Fix any issues that come up
-4. Deploy!
+1. Run through the manual tests (1-2 hours)
+2. Fix any issues that come up
+3. Deploy when ready
+
+Do not configure OpenAI keys in Flutter/web. Future AI setup must use
+Firebase Functions/server-side secrets only.
 
 **Estimated total time: 3-4 hours to deployment**
 

--- a/test-ai-config.ps1
+++ b/test-ai-config.ps1
@@ -1,37 +1,19 @@
-# Quick test to check if AI is configured
-# Run this in VS Code terminal: .\test-ai-config.ps1
+# Deprecated frontend OpenAI configuration check.
+#
+# This script is intentionally no longer used for Flutter web setup.
+# Do not put OpenAI API keys in Flutter/web code, --dart-define, VS Code launch
+# config, .vscode/settings.json, or client-side environment variables.
+#
+# Safe direction:
+# Flutter UI -> service wrapper -> Firebase callable Function -> OpenAI API
+# Store OpenAI credentials only in Firebase Functions / Google Cloud
+# server-side secret storage.
 
-Write-Host "`n🤖 AI Configuration Test" -ForegroundColor Cyan
-Write-Host "========================`n" -ForegroundColor Cyan
-
-# Check if environment variable exists
-$apiKey = $env:OPENAI_API_KEY
-
-if ($null -eq $apiKey -or $apiKey -eq "") {
-    Write-Host "❌ OPENAI_API_KEY not found in environment" -ForegroundColor Red
-    Write-Host "`nTo fix this:" -ForegroundColor Yellow
-    Write-Host "1. Edit .vscode/settings.json" -ForegroundColor White
-    Write-Host "2. Uncomment the terminal.integrated.env.windows section" -ForegroundColor White
-    Write-Host "3. Add your API key" -ForegroundColor White
-    Write-Host "4. Restart VS Code completely`n" -ForegroundColor White
-    Write-Host "See AI_SETUP_QUICK.md for help`n" -ForegroundColor Cyan
-    exit 1
-}
-
-# Check format
-if ($apiKey -notmatch '^sk-[a-zA-Z0-9_-]+$') {
-    Write-Host "⚠️  API key format looks incorrect" -ForegroundColor Yellow
-    Write-Host "   Expected: sk-..." -ForegroundColor White
-    Write-Host "   Got: $($apiKey.Substring(0, [Math]::Min(10, $apiKey.Length)))..." -ForegroundColor White
-    Write-Host "`n   Make sure you copied the full key`n" -ForegroundColor Yellow
-    exit 1
-}
-
-# All good
-Write-Host "✅ API key found in environment" -ForegroundColor Green
-Write-Host "✅ Key format looks correct" -ForegroundColor Green
-Write-Host "`n🎉 AI is configured!" -ForegroundColor Green
-Write-Host "`nNext steps:" -ForegroundColor Cyan
-Write-Host "1. Press F5 in VS Code" -ForegroundColor White
-Write-Host "2. Select 'Flutter (Chrome) + AI 🤖'" -ForegroundColor White
-Write-Host "3. Try importing a file to test AI features`n" -ForegroundColor White
+Write-Host ""
+Write-Host "Deprecated OpenAI frontend setup check" -ForegroundColor Yellow
+Write-Host "======================================" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "Do not configure OpenAI keys for Flutter/web or VS Code launch configs." -ForegroundColor Red
+Write-Host "Use Firebase Functions/server-side secrets only when real OpenAI integration is added." -ForegroundColor Cyan
+Write-Host ""
+exit 1


### PR DESCRIPTION
﻿## Files changed
- `.env.example`
- `.vscode/settings.json`
- `AI_SETUP_QUICK.md`, `SETUP_AI.md`, `START_HERE_AI.md`, `AI_INTEGRATION_GUIDE.md`
- `test-ai-config.ps1`
- `SECURITY.md`, `SECURITY_INCIDENT_RESPONSE.md`
- README/status/testing/developer docs that referenced frontend OpenAI setup

## Unsafe guidance found
- Older docs instructed putting OpenAI keys in VS Code settings, local terminal environment variables, `.env`, or Flutter `--dart-define` values.
- Some testing and status docs implied validating frontend/client-side OpenAI key setup.
- `.env.example` suggested direct OpenAI endpoint/key values for Flutter/web use.

## Real secret audit
- No real-looking OpenAI secret was found in tracked files during the redacted audit.
- Historical/redacted incident references were treated as sensitive and replaced with server-side-only guidance.

## What changed
- Quarantined deprecated frontend AI setup docs with clear safety warnings.
- Replaced unsafe setup examples with Firebase Functions/server-side secret guidance.
- Updated `.env.example`, VS Code settings comments, testing docs, status docs, and security docs to say OpenAI keys must not be placed in Flutter/web code, `--dart-define`, VS Code launch config, or client-side environment variables.
- Updated the old local AI config test script so it warns that frontend key setup is deprecated.

## Verification
- `git diff` reviewed.
- `flutter analyze` passed.
- `flutter test` passed.
- `flutter build web --release --no-wasm-dry-run` passed.

No real OpenAI integration was added. Firebase Functions behavior, Ask InstructOS behavior, Firebase config, Firestore, and Flutter UI behavior were not changed.
