### PR TITLE
Add server-side OpenAI path for Ask InstructOS

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,10 +1,17 @@
 import {logger} from "firebase-functions";
+import {defineSecret} from "firebase-functions/params";
 import {HttpsError, onCall} from "firebase-functions/v2/https";
 
 const MAX_MESSAGE_LENGTH = 2000;
 const MAX_CONVERSATION_ITEMS = 20;
 const MAX_CONVERSATION_CONTENT_LENGTH = 2000;
 const MAX_CONTEXT_MODE_LENGTH = 64;
+const OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
+const OPENAI_MODEL = "gpt-4.1-mini";
+const OPENAI_TIMEOUT_MS = 12000;
+const OPENAI_MAX_OUTPUT_TOKENS = 450;
+
+const OPENAI_API_KEY = defineSecret("OPENAI_API_KEY");
 
 type AssistantRole = "user" | "assistant" | "system";
 
@@ -26,9 +33,20 @@ interface AskInstructOSResponse {
 const PLACEHOLDER_REPLY =
   "Ask InstructOS backend is ready. Real AI connection will be added in a later slice.";
 
+const PROVIDER_FALLBACK_REPLY =
+  "Ask InstructOS is temporarily unable to reach the AI provider. Please try again soon.";
+
+const ASSISTANT_INSTRUCTIONS = [
+  "Ask InstructOS is a teacher assistant inside InstructOS.",
+  "It can help plan lessons, draft ideas, create quizzes, and organise teaching work.",
+  "It must not claim access to class data, student records, planner data, or live app tools yet.",
+  "It should be concise, useful, and teacher-friendly.",
+  "It should refuse to pretend it has accessed data it has not been given.",
+].join(" ");
+
 export const askInstructOS = onCall<AskInstructOSPayload>(
-  {region: "us-central1"},
-  (request): AskInstructOSResponse => {
+  {region: "us-central1", secrets: [OPENAI_API_KEY]},
+  async (request): Promise<AskInstructOSResponse> => {
     if (!request.auth) {
       throw new HttpsError(
         "unauthenticated",
@@ -40,16 +58,151 @@ export const askInstructOS = onCall<AskInstructOSPayload>(
 
     // Do not log full user messages. Keep logs limited to safe operational
     // metadata until privacy review, rate limiting, and real AI are added.
-    logger.info("Ask InstructOS placeholder invoked", {
+    logger.info("Ask InstructOS invoked", {
       uid: request.auth.uid,
       messageLength: payload.message.length,
       conversationItems: payload.conversation?.length ?? 0,
       contextMode: payload.contextMode ?? "none",
     });
 
-    return {reply: PLACEHOLDER_REPLY};
+    const apiKey = getOpenAiApiKey();
+    if (apiKey === undefined) {
+      logger.info("Ask InstructOS OpenAI secret unavailable; using fallback", {
+        uid: request.auth.uid,
+        messageLength: payload.message.length,
+        conversationItems: payload.conversation?.length ?? 0,
+        contextMode: payload.contextMode ?? "none",
+      });
+      return {reply: PLACEHOLDER_REPLY};
+    }
+
+    const reply = await fetchOpenAiReply(payload, apiKey, request.auth.uid);
+    return {reply};
   },
 );
+
+function getOpenAiApiKey(): string | undefined {
+  try {
+    const value = OPENAI_API_KEY.value().trim();
+    return value.length === 0 ? undefined : value;
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchOpenAiReply(
+  payload: AskInstructOSPayload,
+  apiKey: string,
+  uid: string,
+): Promise<string> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), OPENAI_TIMEOUT_MS);
+  const startedAt = Date.now();
+
+  try {
+    const response = await fetch(OPENAI_RESPONSES_URL, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: OPENAI_MODEL,
+        instructions: ASSISTANT_INSTRUCTIONS,
+        input: buildOpenAiInput(payload),
+        max_output_tokens: OPENAI_MAX_OUTPUT_TOKENS,
+      }),
+      signal: controller.signal,
+    });
+
+    const latencyMs = Date.now() - startedAt;
+    if (!response.ok) {
+      logger.warn("Ask InstructOS OpenAI request failed", {
+        uid,
+        status: response.status,
+        statusClass: `${Math.floor(response.status / 100)}xx`,
+        latencyMs,
+      });
+      return PROVIDER_FALLBACK_REPLY;
+    }
+
+    const data = await response.json() as unknown;
+    const reply = extractOpenAiReply(data);
+    if (reply === undefined) {
+      logger.warn("Ask InstructOS OpenAI response missing text", {
+        uid,
+        latencyMs,
+      });
+      return PROVIDER_FALLBACK_REPLY;
+    }
+
+    logger.info("Ask InstructOS OpenAI request succeeded", {
+      uid,
+      latencyMs,
+      replyLength: reply.length,
+    });
+    return reply;
+  } catch (error) {
+    const latencyMs = Date.now() - startedAt;
+    logger.warn("Ask InstructOS OpenAI request errored", {
+      uid,
+      latencyMs,
+      errorName: error instanceof Error ? error.name : "unknown",
+    });
+    return PROVIDER_FALLBACK_REPLY;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function buildOpenAiInput(payload: AskInstructOSPayload): string {
+  const lines = [
+    "Use only the information below. Do not claim access to app data or tools.",
+  ];
+
+  if (payload.contextMode !== undefined) {
+    lines.push(`Context mode: ${payload.contextMode}`);
+  }
+
+  if (payload.conversation !== undefined && payload.conversation.length > 0) {
+    lines.push("Recent conversation:");
+    for (const item of payload.conversation) {
+      lines.push(`${item.role}: ${item.content}`);
+    }
+  }
+
+  lines.push(`Current user message: ${payload.message}`);
+  return lines.join("\n");
+}
+
+function extractOpenAiReply(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+
+  const outputText = value.output_text;
+  if (typeof outputText === "string" && outputText.trim().length > 0) {
+    return outputText.trim();
+  }
+
+  const output = value.output;
+  if (!Array.isArray(output)) return undefined;
+
+  const chunks: string[] = [];
+  for (const item of output) {
+    if (!isRecord(item)) continue;
+    const content = item.content;
+    if (!Array.isArray(content)) continue;
+    for (const contentItem of content) {
+      if (!isRecord(contentItem)) continue;
+      const text = contentItem.text;
+      if (typeof text === "string" && text.trim().length > 0) {
+        chunks.push(text.trim());
+      }
+    }
+  }
+
+  const reply = chunks.join("\n").trim();
+  return reply.length === 0 ? undefined : reply;
+}
 
 function validatePayload(value: unknown): AskInstructOSPayload {
   if (!isRecord(value)) {


### PR DESCRIPTION
﻿## Summary
- Added the first server-side OpenAI provider path inside the existing `askInstructOS` Firebase callable.
- Kept Flutter payload shape unchanged: `{ message, conversation?, contextMode? }`.
- Kept the change scoped to `functions/src/index.ts` only.

## Files changed
- `functions/src/index.ts`

## Secret binding
- Binds `OPENAI_API_KEY` with Firebase Functions v2 secret support via `defineSecret("OPENAI_API_KEY")` and `secrets: [OPENAI_API_KEY]` on `askInstructOS`.
- No secret value, API key, `.env`, VS Code config, Flutter/web key, or `--dart-define` key was added.

## Missing-secret behavior
- If `OPENAI_API_KEY` is unavailable or empty at runtime, the callable returns the existing placeholder reply:
  `Ask InstructOS backend is ready. Real AI connection will be added in a later slice.`
- This keeps local/emulator and pre-secret environments from crashing.

## API/model style
- Uses Node 20 built-in `fetch`; no OpenAI SDK or new dependency was added.
- Calls the OpenAI Responses API endpoint from Firebase Functions only.
- Uses `gpt-4.1-mini` as the conservative first model default.
- Uses bounded output (`max_output_tokens`) and a 12 second provider timeout.

## Safety boundaries
- Firebase Auth is still required.
- Existing message, conversation, and `contextMode` validation remains.
- Logs safe metadata only: UID, lengths/counts, status class, latency, reply length.
- Does not log full prompts, model replies, provider bodies, or secrets.
- Does not add class/student/planner context.
- Does not read or write Firestore.
- Does not add streaming, tool calling, or voice.
- Does not change Flutter UI or `InstructOSAssistantService`.
- Does not reintroduce any frontend OpenAI path.
- Does not deploy Firebase.

## Testing notes
- The repo does not currently include a Functions test harness or test script, so no committed Functions tests were added in this slice.
- Local compiled callable invocation was used to validate:
  - unauthenticated request returns `unauthenticated`
  - authenticated missing-secret request returns the placeholder fallback
- A full Firebase emulator smoke test was attempted, but the local CLI did not start the Auth emulator because it is not initialized in `firebase.json`, and Functions trigger discovery timed out before loading the callable. This PR does not change emulator config.

## Verification
- `cd functions && npm run lint` passed.
- `cd functions && npm run build` passed.
- `flutter analyze` passed on rerun; first attempt timed out at the tool level before diagnostics.
- `flutter test` passed.
- `flutter build web --release --no-wasm-dry-run` passed.
- `git diff --check` passed.
- Redacted tracked-file scan found 0 `sk-` style secret-like values.
- `rg` search found no frontend OpenAI path reintroduced in `lib` or `test`.

## Explicit non-goals
No key, deploy, frontend OpenAI path, class/student/planner context, Firestore writes, tool calling, voice, Flutter UI change, or new dependency was added.
