### PR TITLE
Fix OS Home startup hydration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -30,12 +28,6 @@ void main() async {
   }
 
   runApp(const MyApp());
-
-  if (kIsWeb) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      unawaited(FirebaseService.maybeInitialize());
-    });
-  }
 }
 
 class MyApp extends StatefulWidget {

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -57,7 +57,14 @@ class AppProviders extends StatelessWidget {
         ProxyProvider<GoogleAuthService, GoogleDriveService>(
           update: (_, auth, __) => GoogleDriveService(authService: auth),
         ),
-        ChangeNotifierProvider(create: (_) => ClassService()),
+        ChangeNotifierProxyProvider<AuthService, ClassService>(
+          create: (_) => ClassService(),
+          update: (_, auth, service) {
+            service ??= ClassService();
+            service.syncAuth(auth);
+            return service;
+          },
+        ),
         ChangeNotifierProvider(create: (_) => StudentService()),
         ChangeNotifierProvider(create: (_) => GradingCategoryService()),
         ChangeNotifierProvider(create: (_) => GradeItemService()),

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -30,8 +30,12 @@ class AuthService extends ChangeNotifier {
     if (_initialized || _isLoading) return;
     _isLoading = true;
     // Do not notify here to avoid setState/markNeedsBuild during build
-    
+
     try {
+      if (kIsWeb && !FirebaseService.isInitialized) {
+        await FirebaseService.maybeInitialize();
+      }
+
       if (FirebaseService.isAvailable) {
         final u = fb.FirebaseAuth.instance.currentUser;
         if (u != null) {
@@ -45,7 +49,8 @@ class AuthService extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       final userJson = prefs.getString(_currentUserKey);
       if (userJson != null) {
-        _currentUser = User.fromJson(json.decode(userJson) as Map<String, dynamic>);
+        _currentUser =
+            User.fromJson(json.decode(userJson) as Map<String, dynamic>);
       }
     } catch (e) {
       debugPrint('Failed to load current user: $e');
@@ -114,7 +119,8 @@ class AuthService extends ChangeNotifier {
         await MigrationService.maybeMigrateLocalToFirestore(userId: u.uid);
 
         final prefs = await SharedPreferences.getInstance();
-        await prefs.setString(_currentUserKey, json.encode(_currentUser!.toJson()));
+        await prefs.setString(
+            _currentUserKey, json.encode(_currentUser!.toJson()));
 
         _isLoading = false;
         notifyListeners();
@@ -122,14 +128,16 @@ class AuthService extends ChangeNotifier {
       }
 
       final googleAuth = _googleAuth ?? GoogleAuthService();
-      final result = await googleAuth.ensureAccessTokenDetailed(interactive: true);
+      final result =
+          await googleAuth.ensureAccessTokenDetailed(interactive: true);
       if (!result.ok) {
         _isLoading = false;
         notifyListeners();
         return false;
       }
       if (!result.hasIdToken) {
-        debugPrint('Google sign-in did not return an idToken; cannot sign into FirebaseAuth.');
+        debugPrint(
+            'Google sign-in did not return an idToken; cannot sign into FirebaseAuth.');
         _isLoading = false;
         notifyListeners();
         return false;
@@ -139,7 +147,8 @@ class AuthService extends ChangeNotifier {
         accessToken: result.accessToken,
         idToken: result.idToken,
       );
-      final cred = await fb.FirebaseAuth.instance.signInWithCredential(credential);
+      final cred =
+          await fb.FirebaseAuth.instance.signInWithCredential(credential);
 
       final u = cred.user;
       if (u == null) {
@@ -153,7 +162,8 @@ class AuthService extends ChangeNotifier {
       await MigrationService.maybeMigrateLocalToFirestore(userId: u.uid);
 
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(_currentUserKey, json.encode(_currentUser!.toJson()));
+      await prefs.setString(
+          _currentUserKey, json.encode(_currentUser!.toJson()));
 
       _isLoading = false;
       notifyListeners();
@@ -169,13 +179,14 @@ class AuthService extends ChangeNotifier {
   Future<bool> login(String email, String password) async {
     _isLoading = true;
     notifyListeners();
-    
+
     try {
       // Prefer Firebase Auth when available (production).
       if (FirebaseService.isAvailable) {
         try {
           final cred = await fb.FirebaseAuth.instance
-              .signInWithEmailAndPassword(email: email.trim(), password: password);
+              .signInWithEmailAndPassword(
+                  email: email.trim(), password: password);
           final u = cred.user;
           if (u != null) {
             _currentUser = _userFromFirebase(u);
@@ -201,23 +212,24 @@ class AuthService extends ChangeNotifier {
 
       final prefs = await SharedPreferences.getInstance();
       final usersJson = prefs.getString(_usersKey);
-      
+
       if (usersJson != null) {
         final List<dynamic> usersList = json.decode(usersJson) as List;
         final userMap = usersList.firstWhere(
           (u) => (u as Map<String, dynamic>)['email'] == email,
           orElse: () => null,
         );
-        
+
         if (userMap != null) {
           _currentUser = User.fromJson(userMap as Map<String, dynamic>);
-          await prefs.setString(_currentUserKey, json.encode(_currentUser!.toJson()));
+          await prefs.setString(
+              _currentUserKey, json.encode(_currentUser!.toJson()));
           _isLoading = false;
           notifyListeners();
           return true;
         }
       }
-      
+
       _isLoading = false;
       notifyListeners();
       return false;
@@ -229,10 +241,11 @@ class AuthService extends ChangeNotifier {
     }
   }
 
-  Future<bool> register(String email, String fullName, String? schoolName) async {
+  Future<bool> register(
+      String email, String fullName, String? schoolName) async {
     _isLoading = true;
     notifyListeners();
-    
+
     try {
       // Local-only account creation (demo/offline mode).
       RepositoryFactory.useLocal();
@@ -240,17 +253,18 @@ class AuthService extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       final usersJson = prefs.getString(_usersKey);
       List<Map<String, dynamic>> usersList = [];
-      
+
       if (usersJson != null) {
-        usersList = (json.decode(usersJson) as List).cast<Map<String, dynamic>>();
-        
+        usersList =
+            (json.decode(usersJson) as List).cast<Map<String, dynamic>>();
+
         if (usersList.any((u) => u['email'] == email)) {
           _isLoading = false;
           notifyListeners();
           return false;
         }
       }
-      
+
       final now = DateTime.now();
       final newUser = User(
         userId: const Uuid().v4(),
@@ -260,13 +274,14 @@ class AuthService extends ChangeNotifier {
         createdAt: now,
         updatedAt: now,
       );
-      
+
       usersList.add(newUser.toJson());
       await prefs.setString(_usersKey, json.encode(usersList));
-      
+
       _currentUser = newUser;
-      await prefs.setString(_currentUserKey, json.encode(_currentUser!.toJson()));
-      
+      await prefs.setString(
+          _currentUserKey, json.encode(_currentUser!.toJson()));
+
       _isLoading = false;
       notifyListeners();
       return true;
@@ -281,7 +296,7 @@ class AuthService extends ChangeNotifier {
   Future<void> logout() async {
     _isLoading = true;
     notifyListeners();
-    
+
     try {
       if (FirebaseService.isAvailable) {
         try {
@@ -320,7 +335,8 @@ class AuthService extends ChangeNotifier {
       final usersJson = prefs.getString(_usersKey);
       if (usersJson != null) {
         final List<dynamic> list = json.decode(usersJson) as List<dynamic>;
-        final idx = list.indexWhere((u) => (u as Map<String, dynamic>)['userId'] == updated.userId);
+        final idx = list.indexWhere(
+            (u) => (u as Map<String, dynamic>)['userId'] == updated.userId);
         if (idx != -1) {
           list[idx] = updated.toJson();
           await prefs.setString(_usersKey, json.encode(list));
@@ -336,7 +352,7 @@ class AuthService extends ChangeNotifier {
     try {
       final prefs = await SharedPreferences.getInstance();
       final usersJson = prefs.getString(_usersKey);
-      
+
       if (usersJson == null) {
         final demoUser = User(
           userId: 'demo-teacher-1',
@@ -346,7 +362,7 @@ class AuthService extends ChangeNotifier {
           createdAt: DateTime.now(),
           updatedAt: DateTime.now(),
         );
-        
+
         await prefs.setString(_usersKey, json.encode([demoUser.toJson()]));
         debugPrint('Demo user seeded successfully');
       }

--- a/lib/services/class_service.dart
+++ b/lib/services/class_service.dart
@@ -1,26 +1,58 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:gradeflow/models/class.dart';
 import 'package:gradeflow/repositories/repository_factory.dart';
+import 'package:gradeflow/services/auth_service.dart';
 import 'package:gradeflow/services/class_schedule_service.dart';
 
 class ClassService extends ChangeNotifier {
   List<Class> _classes = [];
   bool _isLoading = false;
+  String? _syncedTeacherId;
+  bool _hasLoadedForSyncedTeacher = false;
 
   // Active classes by default for UI
   List<Class> get classes => _classes.where((c) => !c.isArchived).toList();
-  List<Class> get activeClasses => _classes.where((c) => !c.isArchived).toList();
-  List<Class> get archivedClasses => _classes.where((c) => c.isArchived).toList();
+  List<Class> get activeClasses =>
+      _classes.where((c) => !c.isArchived).toList();
+  List<Class> get archivedClasses =>
+      _classes.where((c) => c.isArchived).toList();
   bool get isLoading => _isLoading;
+
+  void syncAuth(AuthService auth) {
+    if (!auth.isInitialized || auth.isLoading) return;
+
+    final user = auth.currentUser;
+    if (user == null) {
+      final hadState = _syncedTeacherId != null || _classes.isNotEmpty;
+      _syncedTeacherId = null;
+      _hasLoadedForSyncedTeacher = false;
+      _classes = [];
+      if (hadState) notifyListeners();
+      return;
+    }
+
+    if (_syncedTeacherId == user.userId &&
+        (_hasLoadedForSyncedTeacher || _isLoading)) {
+      return;
+    }
+
+    _syncedTeacherId = user.userId;
+    unawaited(loadClasses(user.userId));
+  }
 
   Future<void> loadClasses(String teacherId) async {
     _isLoading = true;
     // Removed early notify to avoid setState/markNeedsBuild during build
-    
+
     try {
       final repo = RepositoryFactory.instance;
       final all = await repo.loadClasses();
       _classes = all.where((c) => c.teacherId == teacherId).toList();
+      if (_syncedTeacherId == teacherId) {
+        _hasLoadedForSyncedTeacher = true;
+      }
     } catch (e) {
       debugPrint('Failed to load classes: $e');
     } finally {
@@ -42,7 +74,8 @@ class ClassService extends ChangeNotifier {
 
   Future<void> updateClass(Class updatedClass) async {
     try {
-      final localIndex = _classes.indexWhere((c) => c.classId == updatedClass.classId);
+      final localIndex =
+          _classes.indexWhere((c) => c.classId == updatedClass.classId);
       if (localIndex == -1) return;
       _classes[localIndex] = updatedClass;
       final repo = RepositoryFactory.instance;
@@ -57,7 +90,8 @@ class ClassService extends ChangeNotifier {
     try {
       final idx = _classes.indexWhere((c) => c.classId == classId);
       if (idx == -1) return;
-      final updated = _classes[idx].copyWith(isArchived: true, updatedAt: DateTime.now());
+      final updated =
+          _classes[idx].copyWith(isArchived: true, updatedAt: DateTime.now());
       await updateClass(updated);
     } catch (e) {
       debugPrint('Failed to archive class: $e');
@@ -68,7 +102,8 @@ class ClassService extends ChangeNotifier {
     try {
       final idx = _classes.indexWhere((c) => c.classId == classId);
       if (idx == -1) return;
-      final updated = _classes[idx].copyWith(isArchived: false, updatedAt: DateTime.now());
+      final updated =
+          _classes[idx].copyWith(isArchived: false, updatedAt: DateTime.now());
       await updateClass(updated);
     } catch (e) {
       debugPrint('Failed to unarchive class: $e');


### PR DESCRIPTION
## Summary
- Ensures Firebase Auth restoration completes on web before AuthService decides whether to use the Firebase user or cached local state.
- Hydrates ClassService from the authenticated user through AppProviders so OS Home can load classes after startup or browser refresh without requiring a manual sign-out/sign-in cycle.
- Keeps OS Home data real: no fake class data, no UI redesign, and no Ask InstructOS/Firebase Function changes.

## Root Cause
Manual sign-in initialized RepositoryFactory with the Firebase user before notifying app providers, then class screens could load from Firestore. Existing-session startup could mark AuthService initialized before Firebase Auth restored on web, fall back to cached user state, and leave the repository/class hydration path pointed at the wrong or empty source.

## Files Changed
- lib/main.dart
- lib/providers/app_providers.dart
- lib/services/auth_service.dart
- lib/services/class_service.dart

## Validation
- flutter analyze
- flutter test test/global_system_shell_service_test.dart test/os_shell_surfaces_test.dart test/login_screen_test.dart

## Notes
- Sign out/sign in should continue to work.
- Browser refresh and already-signed-in startup should now hydrate OS Home from the restored Firebase user.
- Ask InstructOS should receive class count once the startup workspace/classes finish hydrating.
