### PR TITLE
Fix workspace startup hydration timing

### DIFF
--- a/lib/os/surfaces/planner_surface.dart
+++ b/lib/os/surfaces/planner_surface.dart
@@ -54,7 +54,12 @@ class _PlannerSurfaceState extends State<PlannerSurface> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final userId = context.read<AuthService>().currentUser?.userId ?? 'local';
+    final auth = Provider.of<AuthService>(context);
+    final userId = _plannerStorageUserId(auth);
+    if (userId == null) {
+      _planningLoading = true;
+      return;
+    }
     if (_loadedUserId == userId) return;
     _loadedUserId = userId;
     _planningLoading = true;
@@ -65,6 +70,11 @@ class _PlannerSurfaceState extends State<PlannerSurface> {
   void dispose() {
     _reminderCtrl.dispose();
     super.dispose();
+  }
+
+  String? _plannerStorageUserId(AuthService auth) {
+    if (!auth.isInitialized || auth.isLoading) return null;
+    return auth.currentUser?.userId ?? 'local';
   }
 
   Future<void> _loadPlannerState(String userId) async {
@@ -161,25 +171,39 @@ class _PlannerSurfaceState extends State<PlannerSurface> {
     );
   }
 
-  String _remindersPrefsKey() => _preferences.scopedKey(
-        baseKey: _remindersPrefsBaseKey,
-        userId: _loadedUserId ?? 'local',
-      );
+  String? _remindersPrefsKey() {
+    final userId = _loadedUserId;
+    if (userId == null) return null;
+    return _preferences.scopedKey(
+      baseKey: _remindersPrefsBaseKey,
+      userId: userId,
+    );
+  }
 
-  String _timetablePrefsKey() => _preferences.scopedKey(
-        baseKey: _timetablesPrefsBaseKey,
-        userId: _loadedUserId ?? 'local',
-      );
+  String? _timetablePrefsKey() {
+    final userId = _loadedUserId;
+    if (userId == null) return null;
+    return _preferences.scopedKey(
+      baseKey: _timetablesPrefsBaseKey,
+      userId: userId,
+    );
+  }
 
-  String _selectedTimetablePrefsKey() => _preferences.scopedKey(
-        baseKey: _selectedTimetablePrefsBaseKey,
-        userId: _loadedUserId ?? 'local',
-      );
+  String? _selectedTimetablePrefsKey() {
+    final userId = _loadedUserId;
+    if (userId == null) return null;
+    return _preferences.scopedKey(
+      baseKey: _selectedTimetablePrefsBaseKey,
+      userId: userId,
+    );
+  }
 
   Future<void> _saveReminders() async {
     try {
+      final key = _remindersPrefsKey();
+      if (key == null) return;
       await _preferences.writeJsonList(
-        key: _remindersPrefsKey(),
+        key: key,
         items: _reminders
             .map(
               (reminder) => {
@@ -204,12 +228,15 @@ class _PlannerSurfaceState extends State<PlannerSurface> {
 
   Future<void> _saveTimetables() async {
     try {
+      final timetableKey = _timetablePrefsKey();
+      final selectedKey = _selectedTimetablePrefsKey();
+      if (timetableKey == null || selectedKey == null) return;
       await _preferences.writeString(
-        key: _timetablePrefsKey(),
+        key: timetableKey,
         value: jsonEncode(_timetables.map((item) => item.toJson()).toList()),
       );
       await _preferences.writeString(
-        key: _selectedTimetablePrefsKey(),
+        key: selectedKey,
         value: _selectedTimetableId,
       );
     } catch (e) {
@@ -235,7 +262,8 @@ class _PlannerSurfaceState extends State<PlannerSurface> {
     await context.read<GlobalSystemShellController>().refreshWorkspaceSnapshot(
           auth,
         );
-    final userId = auth.currentUser?.userId ?? 'local';
+    final userId = _plannerStorageUserId(auth);
+    if (userId == null) return;
     if (!mounted) return;
     await _loadPlannerState(userId);
   }

--- a/lib/screens/class_detail_screen.dart
+++ b/lib/screens/class_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -38,6 +40,7 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
   String? _driveAccessToken;
   bool _driveSigningIn = false;
   bool _handledInitialAction = false;
+  String? _loadedClassDataUserId;
   final ClassNoteService _classNoteService = ClassNoteService();
 
   void _showFeedback(
@@ -102,15 +105,42 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
   @override
   void initState() {
     super.initState();
-    // Schedule data loading after the first frame to avoid setState during build
+  }
+
+  @override
+  void didUpdateWidget(covariant ClassDetailScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.classId != widget.classId) {
+      _loadedClassDataUserId = null;
+      _handledInitialAction = false;
+      final userId = _classDataUserIdFor(context.read<AuthService>());
+      if (userId != null) {
+        _scheduleLoadData(userId);
+      }
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final auth = Provider.of<AuthService>(context);
+    final userId = _classDataUserIdFor(auth);
+    if (userId == null || _loadedClassDataUserId == userId) return;
+    _scheduleLoadData(userId);
+  }
+
+  void _scheduleLoadData(String userId) {
+    _loadedClassDataUserId = userId;
+    // Schedule data loading after the first frame to avoid setState during build.
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _loadData();
+      if (!mounted || _loadedClassDataUserId != userId) return;
+      unawaited(_loadData(userId));
     });
   }
 
-  String _classDataUserId() {
-    final user = context.read<AuthService>().currentUser;
-    return user?.userId ?? 'local';
+  String? _classDataUserIdFor(AuthService auth) {
+    if (!auth.isInitialized || auth.isLoading) return null;
+    return auth.currentUser?.userId ?? 'local';
   }
 
   DateTime _dateOnly(DateTime value) =>
@@ -149,14 +179,16 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
   }
 
   Future<void> _saveClassNotes() async {
+    final userId = _loadedClassDataUserId;
+    if (userId == null) return;
     await _classNoteService.save(
       classId: widget.classId,
-      userId: _classDataUserId(),
+      userId: userId,
       items: _classNotes,
     );
   }
 
-  Future<void> _loadData() async {
+  Future<void> _loadData(String classDataUserId) async {
     final authService = context.read<AuthService>();
     final classService = context.read<ClassService>();
     final studentService = context.read<StudentService>();
@@ -191,7 +223,7 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
     final items = await scheduleService.load(widget.classId);
     final notes = await _classNoteService.load(
       classId: widget.classId,
-      userId: user?.userId ?? 'local',
+      userId: classDataUserId,
     );
     if (!mounted) return;
     setState(() {
@@ -421,10 +453,23 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final auth = context.watch<AuthService>();
     final classService = context.watch<ClassService>();
     final studentService = context.watch<StudentService>();
     final categoryService = context.watch<GradingCategoryService>();
     final classItem = classService.getClassById(widget.classId);
+
+    if (!auth.isInitialized || auth.isLoading) {
+      return const WorkspaceScaffold(
+        eyebrow: 'Class workspace',
+        title: 'Restoring session',
+        subtitle: 'Loading the teacher workspace for this class.',
+        child: WorkspaceLoadingState(
+          title: 'Restoring class workspace',
+          subtitle: 'Waiting for the signed-in teacher session.',
+        ),
+      );
+    }
 
     if (classItem == null) {
       return const WorkspaceScaffold(

--- a/test/os_shell_surfaces_test.dart
+++ b/test/os_shell_surfaces_test.dart
@@ -1,6 +1,9 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
+import 'package:gradeflow/models/user.dart';
 import 'package:gradeflow/os/gradeflow_os_shell.dart';
 import 'package:gradeflow/os/os_controller.dart';
 import 'package:gradeflow/os/surfaces/home_surface.dart';
@@ -56,6 +59,58 @@ void main() {
     expect(find.text('Upload'), findsOneWidget);
     expect(find.text('Class schedules and assessments'), findsNothing);
     expect(find.text('Where do uploads go?'), findsNothing);
+  });
+
+  testWidgets(
+      'PlannerSurface waits for restored auth before loading scoped data',
+      (tester) async {
+    final user = User(
+      userId: 'teacher-restored',
+      email: 'teacher@example.com',
+      fullName: 'Restored Teacher',
+      schoolName: 'Pilot School',
+      createdAt: DateTime(2026, 5, 1),
+      updatedAt: DateTime(2026, 5, 1),
+    );
+    final auth = AuthService();
+    SharedPreferences.setMockInitialValues({
+      'current_user': jsonEncode(user.toJson()),
+      'dashboard_reminders_v1:local': jsonEncode([
+        {
+          'text': 'Local-only reminder should not hydrate first',
+          'timestamp': DateTime(2026, 5, 2).toIso8601String(),
+          'done': false,
+        }
+      ]),
+      'dashboard_reminders_v1:teacher-restored': jsonEncode([
+        {
+          'text': 'Restored user reminder',
+          'timestamp': DateTime(2026, 5, 3).toIso8601String(),
+          'done': false,
+        }
+      ]),
+    });
+    addTearDown(auth.dispose);
+
+    await tester.pumpWidget(
+      _harness(
+        const PlannerSurface(),
+        auth: auth,
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Local-only reminder should not hydrate first'),
+        findsNothing);
+    expect(find.text('Restored user reminder'), findsNothing);
+
+    await auth.initialize();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 120));
+
+    expect(find.text('Local-only reminder should not hydrate first'),
+        findsNothing);
+    expect(find.text('Restored user reminder'), findsOneWidget);
   });
 
   testWidgets('GradeFlowOSShell shows one overlay at a time', (tester) async {
@@ -120,10 +175,14 @@ void main() {
   });
 }
 
-Widget _harness(Widget child, {GradeFlowOSController? controller}) {
+Widget _harness(
+  Widget child, {
+  GradeFlowOSController? controller,
+  AuthService? auth,
+}) {
   return MultiProvider(
     providers: [
-      ChangeNotifierProvider<AuthService>(create: (_) => AuthService()),
+      ChangeNotifierProvider<AuthService>.value(value: auth ?? AuthService()),
       ChangeNotifierProvider<ClassService>(create: (_) => ClassService()),
       ChangeNotifierProvider<CommunicationService>(
         create: (_) => CommunicationService(),


### PR DESCRIPTION
## Summary

- Prevents Planner from loading user-scoped reminder/timetable preferences under the fallback `local` key while Firebase Auth is still restoring.
- Reloads Planner state when the resolved storage user changes from uninitialized/local to the restored authenticated user.
- Prevents Class Detail from loading class notes under `local` while auth is still initializing, and shows a restore-session loading state for deep-linked class workspaces.
- Keeps class schedules, reminders, timetables, and notes in their existing SharedPreferences formats; this PR does not migrate data to Firestore.

## Root cause

Several workspace surfaces chose `currentUser?.userId ?? 'local'` before `AuthService` had finished initialization. On browser refresh, that could make SharedPreferences-backed workspace data appear empty or bind to the wrong local key until a later manual navigation.

## Validation

- `flutter analyze` - passed
- `flutter test test/os_shell_surfaces_test.dart` - passed
- `flutter test test/class_note_service_test.dart test/class_schedule_docx_test.dart` - passed

## Manual test results

- Planner reminder survived reload - passed.
- Class note/reminder survived reload - passed.
- Demo/local mode sanity test - passed.

## Scope notes

- No UI redesign.
- No Firebase Functions, OpenAI, or secrets changes.
- No Firestore migration.
- Ask InstructOS was not touched.

## Remaining limitation

This PR fixes startup/session hydration timing for local SharedPreferences-backed workspace data. It does not make planner reminders, timetables, class schedules, class notes, or restore bins cross-device synced.