### PR TITLE
GF-041: Generalize workspace startup hydration

### DIFF
--- a/lib/os/surfaces/class_surface.dart
+++ b/lib/os/surfaces/class_surface.dart
@@ -31,6 +31,7 @@ class _ClassSurfaceState extends State<ClassSurface>
     with SingleTickerProviderStateMixin {
   late final TabController _tabs;
   bool _hydrating = false;
+  String? _lastHydrationUserId;
 
   static const _tabDefs = [
     _TabDef(icon: Icons.dashboard_outlined, label: 'Overview'),
@@ -65,12 +66,31 @@ class _ClassSurfaceState extends State<ClassSurface>
     super.didUpdateWidget(oldWidget);
     if (oldWidget.classId != widget.classId) {
       _tabs.index = 0;
+      _lastHydrationUserId = null;
       setState(() {
         _hydrating =
             context.read<ClassService>().getClassById(widget.classId) == null;
       });
       _scheduleHydration();
     }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final auth = Provider.of<AuthService>(context);
+    if (!auth.isInitialized || auth.isLoading) {
+      if (!_hydrating &&
+          context.read<ClassService>().getClassById(widget.classId) == null) {
+        _hydrating = true;
+      }
+      return;
+    }
+
+    final userId = auth.currentUser?.userId ?? 'local';
+    if (_lastHydrationUserId == userId) return;
+    _lastHydrationUserId = userId;
+    _scheduleHydration();
   }
 
   @override
@@ -92,7 +112,15 @@ class _ClassSurfaceState extends State<ClassSurface>
     final classService = context.read<ClassService>();
     final studentService = context.read<StudentService>();
 
+    if (!auth.isInitialized || auth.isLoading) {
+      if (mounted && !_hydrating) {
+        setState(() => _hydrating = true);
+      }
+      return;
+    }
+
     try {
+      _lastHydrationUserId = auth.currentUser?.userId ?? 'local';
       final user = auth.currentUser;
       if (user != null && classService.getClassById(requestedClassId) == null) {
         await classService.loadClasses(user.userId);

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -58,7 +58,10 @@ class _HomeSurfaceState extends State<HomeSurface> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final auth = context.read<AuthService>();
-    _syncWallpaperForUser(auth.currentUser?.userId ?? 'local');
+    final userId = _homeStorageUserId(auth);
+    if (userId != null) {
+      _syncWallpaperForUser(userId);
+    }
   }
 
   void _syncWallpaperForUser(String userId) {
@@ -111,7 +114,12 @@ class _HomeSurfaceState extends State<HomeSurface> {
     }
   }
 
-  String get _wallpaperUserId => _loadedUserId ?? 'local';
+  String? get _wallpaperUserId => _loadedUserId;
+
+  String? _homeStorageUserId(AuthService auth) {
+    if (!auth.isInitialized || auth.isLoading) return null;
+    return auth.currentUser?.userId ?? 'local';
+  }
 
   Future<void> _saveWallpaper({
     _HomeWallpaperStyle? style,
@@ -129,6 +137,7 @@ class _HomeSurfaceState extends State<HomeSurface> {
     });
 
     final userId = _wallpaperUserId;
+    if (userId == null) return;
     await _preferences.writeString(
       key: _preferences.scopedKey(
         baseKey: _wallpaperStyleBaseKey,
@@ -151,10 +160,12 @@ class _HomeSurfaceState extends State<HomeSurface> {
     _HomeReadabilityPreset preset,
   ) async {
     setState(() => _readabilityPreset = preset);
+    final userId = _wallpaperUserId;
+    if (userId == null) return;
     await _preferences.writeString(
       key: _preferences.scopedKey(
         baseKey: _readabilityBaseKey,
-        userId: _wallpaperUserId,
+        userId: userId,
       ),
       value: preset.id,
     );
@@ -303,10 +314,12 @@ class _HomeSurfaceState extends State<HomeSurface> {
     final snapshot = shell.workspaceSnapshot;
     final auth = context.watch<AuthService>();
     final user = auth.currentUser ?? snapshot?.user;
-    final userId = user?.userId ?? 'local';
-    if (_loadedUserId != userId && !_loadingWallpaper) {
+    final wallpaperUserId = _homeStorageUserId(auth);
+    if (wallpaperUserId != null &&
+        _loadedUserId != wallpaperUserId &&
+        !_loadingWallpaper) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) _syncWallpaperForUser(userId);
+        if (mounted) _syncWallpaperForUser(wallpaperUserId);
       });
     }
     final serviceClasses = context.watch<ClassService>().activeClasses;

--- a/lib/screens/class_detail_screen.dart
+++ b/lib/screens/class_detail_screen.dart
@@ -220,7 +220,10 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
     await gradeItemService.loadGradeItems(widget.classId);
 
     // Load schedule + class notes/reminders
-    final items = await scheduleService.load(widget.classId);
+    final items = await scheduleService.load(
+      widget.classId,
+      userId: classDataUserId,
+    );
     final notes = await _classNoteService.load(
       classId: widget.classId,
       userId: classDataUserId,
@@ -1257,7 +1260,11 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
         return;
       }
 
-      await scheduleService.save(widget.classId, items);
+      await scheduleService.save(
+        widget.classId,
+        items,
+        userId: _loadedClassDataUserId,
+      );
       if (!mounted) return;
 
       setState(() {
@@ -1316,7 +1323,11 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
     if (confirm != true) return;
 
     final scheduleService = ClassScheduleService();
-    await scheduleService.save(widget.classId, []);
+    await scheduleService.save(
+      widget.classId,
+      [],
+      userId: _loadedClassDataUserId,
+    );
     if (!mounted) return;
 
     setState(() {
@@ -1464,7 +1475,11 @@ class _ClassDetailScreenState extends State<ClassDetailScreen> {
         return;
       }
 
-      await scheduleService.save(widget.classId, items);
+      await scheduleService.save(
+        widget.classId,
+        items,
+        userId: _loadedClassDataUserId,
+      );
       setState(() {
         _scheduleItems = items;
       });

--- a/lib/screens/class_list_screen.dart
+++ b/lib/screens/class_list_screen.dart
@@ -1566,8 +1566,15 @@ class _ClassListScreenState extends State<ClassListScreen> {
     }
     if (copySchedule) {
       final scheduleService = ClassScheduleService();
-      final schedule = await scheduleService.load(classItem.classId);
-      await scheduleService.save(newClass.classId, schedule);
+      final schedule = await scheduleService.load(
+        classItem.classId,
+        userId: userId,
+      );
+      await scheduleService.save(
+        newClass.classId,
+        schedule,
+        userId: userId,
+      );
     }
     await classService.loadClasses(user.userId);
     if (!mounted) return;

--- a/lib/screens/deleted_classes_screen.dart
+++ b/lib/screens/deleted_classes_screen.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:gradeflow/models/deleted_class_entry.dart';
 import 'package:gradeflow/services/auth_service.dart';
+import 'package:gradeflow/services/class_schedule_service.dart';
 import 'package:gradeflow/services/class_service.dart';
 import 'package:gradeflow/services/class_trash_service.dart';
 import 'package:gradeflow/services/grade_item_service.dart';
 import 'package:gradeflow/services/grading_category_service.dart';
 import 'package:gradeflow/services/student_service.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:gradeflow/components/workspace_shell.dart';
 import 'package:gradeflow/theme.dart';
@@ -93,8 +93,10 @@ class _DeletedClassesScreenState extends State<DeletedClassesScreen> {
       }
 
       // Clear per-class schedule storage (if any)
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.remove('class_schedule_v1:$classId');
+      await ClassScheduleService().clear(
+        classId,
+        userId: entry.classItem.teacherId,
+      );
 
       // Ensure the class itself is gone
       await classSvc.deleteClass(classId);

--- a/lib/screens/teacher_dashboard/dashboard_imports.dart
+++ b/lib/screens/teacher_dashboard/dashboard_imports.dart
@@ -21,8 +21,13 @@ extension TeacherDashboardImportActions on _TeacherDashboardScreenState {
 
   Future<void> _loadClassSchedule(String classId) async {
     if (_scheduleByClass.containsKey(classId)) return;
+    final userId = _dashboardPrefsUserId;
+    if (userId == null) return;
     try {
-      final items = await _classScheduleService.load(classId);
+      final items = await _classScheduleService.load(
+        classId,
+        userId: userId,
+      );
       if (!mounted) return;
       setState(() => _scheduleByClass[classId] = items);
     } catch (e) {
@@ -32,7 +37,13 @@ extension TeacherDashboardImportActions on _TeacherDashboardScreenState {
 
   Future<void> _saveClassSchedule(
       String classId, List<ClassScheduleItem> items) async {
-    await _classScheduleService.save(classId, items);
+    final userId = _dashboardPrefsUserId;
+    if (userId == null) return;
+    await _classScheduleService.save(
+      classId,
+      items,
+      userId: userId,
+    );
     if (!mounted) return;
     setState(() => _scheduleByClass[classId] = items);
   }

--- a/lib/screens/teacher_dashboard/dashboard_persistence.dart
+++ b/lib/screens/teacher_dashboard/dashboard_persistence.dart
@@ -4,9 +4,15 @@ part of '../teacher_dashboard_screen.dart';
 
 extension TeacherDashboardPersistence on _TeacherDashboardScreenState {
   Future<void> _loadReminders() async {
+    final loadUserId = _dashboardPrefsUserId;
+    if (loadUserId == null) return;
     try {
+      final remindersKey = _dashboardPreferencesService.scopedKey(
+        baseKey: 'dashboard_reminders_v1',
+        userId: loadUserId,
+      );
       final list = await _dashboardPreferencesService.readScopedJsonList(
-        scopedKey: _remindersPrefsKey(),
+        scopedKey: remindersKey,
         legacyKey: _TeacherDashboardScreenState._legacyRemindersPrefsKey,
         migrationFlagKey:
             _TeacherDashboardScreenState._remindersMigrationFlagKey,
@@ -25,7 +31,7 @@ extension TeacherDashboardPersistence on _TeacherDashboardScreenState {
           classIds: ids == null || ids.isEmpty ? null : ids,
         );
       }).toList();
-      if (!mounted) {
+      if (!mounted || _dashboardPrefsUserId != loadUserId) {
         return;
       }
       setState(() {
@@ -56,8 +62,18 @@ extension TeacherDashboardPersistence on _TeacherDashboardScreenState {
     }
   }
 
+  String? _resolvedDashboardStorageUserId() {
+    final auth = context.read<AuthService>();
+    if (!auth.isInitialized || auth.isLoading) return null;
+    return auth.currentUser?.userId ?? 'local';
+  }
+
   String _dashboardStorageUserId() {
-    return context.read<AuthService>().currentUser?.userId ?? 'local';
+    final userId = _dashboardPrefsUserId;
+    if (userId == null) {
+      throw StateError('Dashboard preferences user is not resolved yet.');
+    }
+    return userId;
   }
 
   String _remindersPrefsKey() => _dashboardPreferencesService.scopedKey(
@@ -195,12 +211,22 @@ extension TeacherDashboardPersistence on _TeacherDashboardScreenState {
   }
 
   Future<void> _loadTimetables() async {
+    final loadUserId = _dashboardPrefsUserId;
+    if (loadUserId == null) return;
     try {
+      final timetableKey = _dashboardPreferencesService.scopedKey(
+        baseKey: 'dashboard_timetables_v1',
+        userId: loadUserId,
+      );
+      final selectedTimetableKey = _dashboardPreferencesService.scopedKey(
+        baseKey: 'dashboard_selected_timetable_v1',
+        userId: loadUserId,
+      );
       final raw = await _dashboardPreferencesService.readScopedString(
-        scopedKey: _timetablePrefsKey(),
+        scopedKey: timetableKey,
       );
       final selectedId = await _dashboardPreferencesService.readScopedString(
-        scopedKey: _selectedTimetablePrefsKey(),
+        scopedKey: selectedTimetableKey,
       );
 
       final parsed = <_Timetable>[];
@@ -212,7 +238,7 @@ extension TeacherDashboardPersistence on _TeacherDashboardScreenState {
         }
       }
 
-      if (!mounted) {
+      if (!mounted || _dashboardPrefsUserId != loadUserId) {
         return;
       }
       setState(() {

--- a/lib/screens/teacher_dashboard_screen.dart
+++ b/lib/screens/teacher_dashboard_screen.dart
@@ -304,7 +304,10 @@ class _TeacherDashboardScreenState extends State<TeacherDashboardScreen> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final userId = _dashboardStorageUserId();
+    final userId = _resolvedDashboardStorageUserId();
+    if (userId == null) {
+      return;
+    }
     if (_dashboardPrefsUserId == userId) return;
     _dashboardPrefsUserId = userId;
     _dashboardLayoutReady = false;
@@ -312,6 +315,15 @@ class _TeacherDashboardScreenState extends State<TeacherDashboardScreen> {
     _dashboardRailSelectedClassId = null;
     _dashboardClassSelectionReady = false;
     _dashboardClassSelectionConfirmed = false;
+    _classes = [];
+    _totalStudents = 0;
+    _reminders.clear();
+    _timetables.clear();
+    _selectedTimetableId = null;
+    _customLinks.clear();
+    _customAudioStations.clear();
+    _selectedAudioStationId = null;
+    _scheduleByClass.clear();
     unawaited(_loadDashboardLayout());
     unawaited(_loadData());
     unawaited(_loadReminders());
@@ -642,6 +654,8 @@ class _TeacherDashboardScreenState extends State<TeacherDashboardScreen> {
   Future<void> _loadData() async {
     final auth = context.read<AuthService>();
     final classService = context.read<ClassService>();
+    final dashboardUserId = _dashboardPrefsUserId;
+    if (dashboardUserId == null) return;
     final storedSelectedClassId = await _loadStoredSelectedDashboardClassId();
 
     if (mounted && _dashboardClassSelectionReady) {
@@ -650,12 +664,15 @@ class _TeacherDashboardScreenState extends State<TeacherDashboardScreen> {
 
     final user = auth.currentUser;
     if (user == null) return;
+    if (_dashboardPrefsUserId != dashboardUserId) return;
 
     await classService.loadClasses(user.userId);
+    if (_dashboardPrefsUserId != dashboardUserId) return;
     final healthSignals = await _classHealthService.loadStaticSignals(
       userId: user.userId,
       classes: classService.classes,
     );
+    if (_dashboardPrefsUserId != dashboardUserId) return;
     final classes = <_ClassBrief>[];
     int totalStudents = 0;
     for (final c in classService.classes) {

--- a/lib/services/class_schedule_service.dart
+++ b/lib/services/class_schedule_service.dart
@@ -51,7 +51,11 @@ class ClassScheduleService {
     String? userId,
   }) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_key(classId, userId: userId));
+    final scopedKey = _key(classId, userId: userId);
+    await prefs.remove(scopedKey);
+    if (scopedKey != _key(classId)) {
+      await prefs.remove(_key(classId));
+    }
   }
 
   List<ClassScheduleItem> parseFromBytes(Uint8List bytes) {

--- a/lib/services/class_schedule_service.dart
+++ b/lib/services/class_schedule_service.dart
@@ -6,30 +6,52 @@ import 'package:gradeflow/services/file_import_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class ClassScheduleService {
-  static String _key(String classId) => 'class_schedule_v1:$classId';
+  static String _key(String classId, {String? userId}) {
+    if (userId == null || userId.trim().isEmpty) {
+      return 'class_schedule_v1:$classId';
+    }
+    return 'class_schedule_v1:$userId:$classId';
+  }
 
-  Future<List<ClassScheduleItem>> load(String classId) async {
+  Future<List<ClassScheduleItem>> load(
+    String classId, {
+    String? userId,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
-    final raw = prefs.getString(_key(classId));
+    final scopedKey = _key(classId, userId: userId);
+    final legacyKey = _key(classId);
+    final raw = prefs.getString(scopedKey) ??
+        (scopedKey == legacyKey ? null : prefs.getString(legacyKey));
     if (raw == null || raw.trim().isEmpty) return const [];
 
     final decoded = jsonDecode(raw);
     if (decoded is! List) return const [];
-    return decoded
+    final items = decoded
         .whereType<Map>()
         .map((m) => ClassScheduleItem.fromJson(Map<String, dynamic>.from(m)))
         .toList();
+    if (scopedKey != legacyKey && prefs.getString(scopedKey) == null) {
+      await prefs.setString(scopedKey, raw);
+    }
+    return items;
   }
 
-  Future<void> save(String classId, List<ClassScheduleItem> items) async {
+  Future<void> save(
+    String classId,
+    List<ClassScheduleItem> items, {
+    String? userId,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
     final data = items.map((i) => i.toJson()).toList();
-    await prefs.setString(_key(classId), jsonEncode(data));
+    await prefs.setString(_key(classId, userId: userId), jsonEncode(data));
   }
 
-  Future<void> clear(String classId) async {
+  Future<void> clear(
+    String classId, {
+    String? userId,
+  }) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(_key(classId));
+    await prefs.remove(_key(classId, userId: userId));
   }
 
   List<ClassScheduleItem> parseFromBytes(Uint8List bytes) {

--- a/lib/services/demo_data_service.dart
+++ b/lib/services/demo_data_service.dart
@@ -80,6 +80,7 @@ class DemoDataService {
 
       await _seedDemoScheduleIfNeeded(
         classItem: classItem,
+        userId: teacherId,
         scheduleService: scheduleService,
       );
       await _seedDemoNotesIfNeeded(
@@ -98,9 +99,13 @@ class DemoDataService {
 
   static Future<void> _seedDemoScheduleIfNeeded({
     required Class classItem,
+    required String userId,
     required ClassScheduleService scheduleService,
   }) async {
-    final existing = await scheduleService.load(classItem.classId);
+    final existing = await scheduleService.load(
+      classItem.classId,
+      userId: userId,
+    );
     if (existing.isNotEmpty) return;
 
     final now = DateTime.now();
@@ -147,7 +152,11 @@ class DemoDataService {
       ),
     ];
 
-    await scheduleService.save(classItem.classId, items);
+    await scheduleService.save(
+      classItem.classId,
+      items,
+      userId: userId,
+    );
   }
 
   static Future<void> _seedDemoNotesIfNeeded({

--- a/test/class_schedule_service_test.dart
+++ b/test/class_schedule_service_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:gradeflow/models/class_schedule_item.dart';
+import 'package:gradeflow/services/class_schedule_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('class schedule service scopes schedules per user', () async {
+    final service = ClassScheduleService();
+
+    await service.save(
+      'shared-class-id',
+      const [
+        ClassScheduleItem(title: 'Teacher one schedule'),
+      ],
+      userId: 'teacher-1',
+    );
+    await service.save(
+      'shared-class-id',
+      const [
+        ClassScheduleItem(title: 'Teacher two schedule'),
+      ],
+      userId: 'teacher-2',
+    );
+
+    final teacherOne = await service.load(
+      'shared-class-id',
+      userId: 'teacher-1',
+    );
+    final teacherTwo = await service.load(
+      'shared-class-id',
+      userId: 'teacher-2',
+    );
+
+    expect(teacherOne.single.title, 'Teacher one schedule');
+    expect(teacherTwo.single.title, 'Teacher two schedule');
+  });
+
+  test('class schedule service migrates legacy class schedule keys', () async {
+    final service = ClassScheduleService();
+
+    await service.save(
+      'legacy-class-id',
+      const [
+        ClassScheduleItem(title: 'Legacy schedule'),
+      ],
+    );
+
+    final scoped = await service.load(
+      'legacy-class-id',
+      userId: 'teacher-restored',
+    );
+    final reloaded = await service.load(
+      'legacy-class-id',
+      userId: 'teacher-restored',
+    );
+
+    expect(scoped.single.title, 'Legacy schedule');
+    expect(reloaded.single.title, 'Legacy schedule');
+  });
+}

--- a/test/class_schedule_service_test.dart
+++ b/test/class_schedule_service_test.dart
@@ -63,4 +63,33 @@ void main() {
     expect(scoped.single.title, 'Legacy schedule');
     expect(reloaded.single.title, 'Legacy schedule');
   });
+
+  test('clear with user id removes scoped and legacy schedule keys', () async {
+    final service = ClassScheduleService();
+
+    await service.save(
+      'class-to-clear',
+      const [
+        ClassScheduleItem(title: 'Legacy schedule'),
+      ],
+    );
+    await service.save(
+      'class-to-clear',
+      const [
+        ClassScheduleItem(title: 'Scoped schedule'),
+      ],
+      userId: 'teacher-restored',
+    );
+
+    await service.clear('class-to-clear', userId: 'teacher-restored');
+
+    final scoped = await service.load(
+      'class-to-clear',
+      userId: 'teacher-restored',
+    );
+    final legacy = await service.load('class-to-clear');
+
+    expect(scoped, isEmpty);
+    expect(legacy, isEmpty);
+  });
 }

--- a/test/demo_data_service_test.dart
+++ b/test/demo_data_service_test.dart
@@ -42,7 +42,10 @@ void main() {
     expect(classService.classes, isNotEmpty);
 
     final firstClass = classService.classes.first;
-    final schedule = await ClassScheduleService().load(firstClass.classId);
+    final schedule = await ClassScheduleService().load(
+      firstClass.classId,
+      userId: DemoDataService.demoUserId,
+    );
     final notes = await ClassNoteService().load(
       classId: firstClass.classId,
       userId: DemoDataService.demoUserId,

--- a/test/os_shell_surfaces_test.dart
+++ b/test/os_shell_surfaces_test.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:gradeflow/models/user.dart';
 import 'package:gradeflow/os/gradeflow_os_shell.dart';
 import 'package:gradeflow/os/os_controller.dart';
+import 'package:gradeflow/os/surfaces/class_surface.dart';
 import 'package:gradeflow/os/surfaces/home_surface.dart';
 import 'package:gradeflow/os/surfaces/planner_surface.dart';
 import 'package:gradeflow/providers/app_providers.dart';
@@ -13,6 +14,7 @@ import 'package:gradeflow/services/auth_service.dart';
 import 'package:gradeflow/services/class_service.dart';
 import 'package:gradeflow/services/communication_service.dart';
 import 'package:gradeflow/services/global_system_shell_service.dart';
+import 'package:gradeflow/services/student_service.dart';
 import 'package:gradeflow/theme.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -89,6 +91,31 @@ void main() {
           'done': false,
         }
       ]),
+      'dashboard_timetables_v1:local': jsonEncode([
+        {
+          'id': 'local-table',
+          'name': 'Local-only timetable',
+          'base64': '',
+          'grid': [
+            ['Time', 'Monday'],
+            ['08:00', 'Local-only class block'],
+          ],
+          'uploadedAt': DateTime(2026, 5, 2).toIso8601String(),
+        }
+      ]),
+      'dashboard_timetables_v1:teacher-restored': jsonEncode([
+        {
+          'id': 'restored-table',
+          'name': 'Restored timetable',
+          'base64': '',
+          'grid': [
+            ['Time', 'Monday'],
+            ['08:00', 'Restored timetable class block'],
+          ],
+          'uploadedAt': DateTime(2026, 5, 3).toIso8601String(),
+        }
+      ]),
+      'dashboard_selected_timetable_v1:teacher-restored': 'restored-table',
     });
     addTearDown(auth.dispose);
 
@@ -103,6 +130,8 @@ void main() {
     expect(find.text('Local-only reminder should not hydrate first'),
         findsNothing);
     expect(find.text('Restored user reminder'), findsNothing);
+    expect(find.text('Local-only class block'), findsNothing);
+    expect(find.text('Restored timetable class block'), findsNothing);
 
     await auth.initialize();
     await tester.pump();
@@ -111,6 +140,43 @@ void main() {
     expect(find.text('Local-only reminder should not hydrate first'),
         findsNothing);
     expect(find.text('Restored user reminder'), findsOneWidget);
+    expect(find.text('Local-only class block'), findsNothing);
+    expect(find.text('Restored timetable class block'), findsOneWidget);
+  });
+
+  testWidgets('ClassSurface keeps deep links loading while auth restores',
+      (tester) async {
+    final user = User(
+      userId: 'teacher-restored',
+      email: 'teacher@example.com',
+      fullName: 'Restored Teacher',
+      schoolName: 'Pilot School',
+      createdAt: DateTime(2026, 5, 1),
+      updatedAt: DateTime(2026, 5, 1),
+    );
+    final auth = AuthService();
+    SharedPreferences.setMockInitialValues({
+      'current_user': jsonEncode(user.toJson()),
+    });
+    addTearDown(auth.dispose);
+
+    await tester.pumpWidget(
+      _harness(
+        const ClassSurface(classId: 'class-deep-link'),
+        auth: auth,
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Loading class workspace'), findsOneWidget);
+    expect(find.text('Class not found'), findsNothing);
+
+    await auth.initialize();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 120));
+
+    expect(find.text('Loading class workspace'), findsNothing);
+    expect(find.text('Class not found'), findsOneWidget);
   });
 
   testWidgets('GradeFlowOSShell shows one overlay at a time', (tester) async {
@@ -184,6 +250,7 @@ Widget _harness(
     providers: [
       ChangeNotifierProvider<AuthService>.value(value: auth ?? AuthService()),
       ChangeNotifierProvider<ClassService>(create: (_) => ClassService()),
+      ChangeNotifierProvider<StudentService>(create: (_) => StudentService()),
       ChangeNotifierProvider<CommunicationService>(
         create: (_) => CommunicationService(),
       ),


### PR DESCRIPTION
﻿### Files changed
- `lib/os/surfaces/class_surface.dart`
- `lib/os/surfaces/home_surface.dart`
- `lib/screens/class_detail_screen.dart`
- `lib/screens/class_list_screen.dart`
- `lib/screens/deleted_classes_screen.dart`
- `lib/screens/teacher_dashboard/dashboard_imports.dart`
- `lib/screens/teacher_dashboard/dashboard_persistence.dart`
- `lib/screens/teacher_dashboard_screen.dart`
- `lib/services/class_schedule_service.dart`
- `lib/services/demo_data_service.dart`
- `test/class_schedule_service_test.dart`
- `test/demo_data_service_test.dart`
- `test/os_shell_surfaces_test.dart`

### Root cause
Remaining workspace paths still had startup-time storage key resolution that could fall back to `local` before `AuthService.initialize()` completed, especially dashboard persistence and OS Home wallpaper state. Class schedules also used only `class_schedule_v1:<classId>`, so schedule data was not scoped by restored user identity.

### Behavior fixed
Dashboard reminders/timetables now wait for resolved auth identity before loading scoped keys, and stale async loads are ignored if the resolved user changes. OS Home wallpaper waits for auth before binding storage. Deep-linked class surfaces keep the safe loading state while auth restores instead of briefly showing “Class not found.” Class schedules now support user-scoped storage with legacy key migration, and class detail/dashboard/demo/copy/delete schedule flows pass the resolved user where available.

### Preserved behavior
No Ask InstructOS behavior, Firebase Functions, OpenAI code, secrets, dependencies, login/splash design, OS Home visual design, or broad UI redesign changes were made. Demo/local mode is preserved: after auth initialization resolves with no signed-in user, storage still uses `local`.

### Verification results
- `flutter analyze`  
  `No issues found! (ran in 17.4s)`

- `flutter test`  
  `All tests passed!`

- `flutter build web --release --no-wasm-dry-run`  
  `√ Built build\web`

I also ran targeted tests sequentially after an initial concurrent Flutter test run hit a Windows build asset race:
- `flutter test test/class_schedule_service_test.dart` passed
- `flutter test test/os_shell_surfaces_test.dart` passed
- `flutter test test/demo_data_service_test.dart` passed

### Remaining limitations
Planner/dashboard reminders, timetables, OS Home wallpaper, and class schedules are still SharedPreferences-backed, not fully cross-device synced. Class schedule legacy data is migrated into the scoped key on read, but this PR does not move schedule storage to Firestore. Branch is `fix/gf-041-workspace-startup-hydration`; nothing was merged to `main`.
