### PR TITLE
GF-046: Surface Data Inbox on OS Home

### DIFF
--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -6026,6 +6026,10 @@ class _HomeShortcutShelf extends StatelessWidget {
         onTap: onMessagesTap,
         badge: unread > 0 ? '$unread' : null,
       ),
+      _shortcutFromApp(
+        OSAppId.schoolDataInbox,
+        onTap: () => context.go(AppRoutes.osInbox),
+      ),
       if (showLauncher)
         _HomeShortcutData(
           label: 'Launcher',

--- a/lib/screens/school_data_inbox_screen.dart
+++ b/lib/screens/school_data_inbox_screen.dart
@@ -548,7 +548,7 @@ class _SchoolDataInboxScreenState extends State<SchoolDataInboxScreen> {
                                 _InboxActionCard(
                                   title: 'Import from Google Drive',
                                   subtitle:
-                                      'Browse recent files, folders, and Sheets.',
+                                      'Opens a Drive file list. Choose a file, then preview extracted data before saving.',
                                   icon: Icons.drive_folder_upload_rounded,
                                   selected: _source == _InboxSource.drive,
                                   enabled: !_busy,
@@ -896,7 +896,7 @@ class _InboxHeader extends StatelessWidget {
           ),
           const SizedBox(height: WorkspaceSpacing.sm),
           Text(
-            'Every writing import stops for preview and confirmation.',
+            'Google Drive opens a picker list first; extracted import data is previewed before anything is saved.',
             style: TextStyle(color: OSColors.textSecondary(dark)),
           ),
         ],

--- a/test/os_shell_surfaces_test.dart
+++ b/test/os_shell_surfaces_test.dart
@@ -38,6 +38,7 @@ void main() {
     expect(find.text('Classes'), findsWidgets);
     expect(find.text('Tasks'), findsWidgets);
     expect(find.text('Messages'), findsWidgets);
+    expect(find.text('Data Inbox'), findsWidgets);
     expect(find.text('Insights'), findsWidgets);
     expect(find.text('Create a class to begin staging teaching tools.'),
         findsNothing);

--- a/test/school_data_inbox_screen_test.dart
+++ b/test/school_data_inbox_screen_test.dart
@@ -125,6 +125,18 @@ void main() {
     expect(find.text('School Data Inbox'), findsOneWidget);
     expect(find.text('Upload from computer'), findsOneWidget);
     expect(find.text('Import from Google Drive'), findsOneWidget);
+    expect(
+      find.text(
+        'Opens a Drive file list. Choose a file, then preview extracted data before saving.',
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.text(
+        'Google Drive opens a picker list first; extracted import data is previewed before anything is saved.',
+      ),
+      findsOneWidget,
+    );
     expect(find.text('Class schedule'), findsOneWidget);
     expect(find.text('Teacher timetable'), findsOneWidget);
     expect(find.text('Roster'), findsOneWidget);


### PR DESCRIPTION
﻿### Files changed
- `lib/os/surfaces/home_surface.dart`
- `lib/screens/school_data_inbox_screen.dart`
- `test/os_shell_surfaces_test.dart`
- `test/school_data_inbox_screen_test.dart`

### UX changed
- Added a visible `Data Inbox` entry point to OS Home's pinned/quick app area.
- The new shortcut routes directly to `/os/inbox`.
- Kept the existing Data Inbox launcher tile.
- Updated School Data Inbox copy so the Google Drive source card explains that Drive opens a file picker/list first, teachers choose a file, and GradeFlow previews extracted import data before saving.

### Preserved behavior
- No import logic changes.
- No full Google Drive document preview or rendering.
- No Google Drive auto-sync, Drive folder pinning, or background polling.
- No Ask InstructOS, AI/OpenAI, Firebase Functions, secrets, auth logic, dependency, or storage migration changes.

### Verification results
- `flutter analyze`: `No issues found! (ran in 33.6s)`
- `flutter test test/os_shell_surfaces_test.dart test/school_data_inbox_screen_test.dart`: `All tests passed!`
- `flutter test test/school_data_inbox_screen_test.dart`: `All tests passed!`
- `flutter test`: `All tests passed!`
- `flutter build web --release --no-wasm-dry-run`: `√ Built build\web`

### Remaining limitations
Full Drive document preview, Drive folder pinning, auto-sync, import history, undo, roster/scores/timetable imports, and AI extraction remain future work.
