### PR TITLE
GF-047: Redesign Data Inbox as a premium school data entry point

### DIFF
--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -666,6 +666,7 @@ class _HomeDesktopLayoutState extends State<_HomeDesktopLayout> {
                       onMessagesTap: () => _openMiniApp(_HomeMiniApp.messages),
                       onPlannerTap: () => _openMiniApp(_HomeMiniApp.agenda),
                       onClassesTap: () => _openMiniApp(_HomeMiniApp.classes),
+                      onInboxTap: () => context.go(AppRoutes.osInbox),
                     ),
                   ),
                   const SizedBox(height: 14),
@@ -4451,6 +4452,7 @@ class _HomeStackedLayoutState extends State<_HomeStackedLayout> {
             onMessagesTap: () => _openMiniApp(_HomeMiniApp.messages),
             onPlannerTap: () => _openMiniApp(_HomeMiniApp.agenda),
             onClassesTap: () => _openMiniApp(_HomeMiniApp.classes),
+            onInboxTap: () => context.go(AppRoutes.osInbox),
           ),
         ),
         const SizedBox(height: 14),
@@ -5548,6 +5550,7 @@ class _HomeStagePanel extends StatelessWidget {
     required this.onMessagesTap,
     required this.onPlannerTap,
     required this.onClassesTap,
+    required this.onInboxTap,
   });
 
   final String teacherName;
@@ -5563,6 +5566,7 @@ class _HomeStagePanel extends StatelessWidget {
   final VoidCallback onMessagesTap;
   final VoidCallback onPlannerTap;
   final VoidCallback onClassesTap;
+  final VoidCallback onInboxTap;
 
   @override
   Widget build(BuildContext context) {
@@ -5676,6 +5680,16 @@ class _HomeStagePanel extends StatelessWidget {
                             : _trimLine(primaryReminder!.text, 88),
                         onTap: onPlannerTap,
                       ),
+                      const SizedBox(height: 12),
+                      _StageSpotlightTile(
+                        title: 'Import school data',
+                        icon: Icons.cloud_upload_rounded,
+                        accent: OSColors.cyan,
+                        headline: 'Data Inbox',
+                        detail:
+                            'Upload calendars, schedules, and school files.',
+                        onTap: onInboxTap,
+                      ),
                     ],
                   ),
                 ],
@@ -5692,6 +5706,7 @@ class _HomeStagePanel extends StatelessWidget {
               onMessagesTap: onMessagesTap,
               onPlannerTap: onPlannerTap,
               onClassesTap: onClassesTap,
+              onInboxTap: onInboxTap,
             ),
     );
   }
@@ -5709,6 +5724,7 @@ class _DesktopStageShell extends StatelessWidget {
     required this.onMessagesTap,
     required this.onPlannerTap,
     required this.onClassesTap,
+    required this.onInboxTap,
   });
 
   final String teacherName;
@@ -5721,6 +5737,7 @@ class _DesktopStageShell extends StatelessWidget {
   final VoidCallback onMessagesTap;
   final VoidCallback onPlannerTap;
   final VoidCallback onClassesTap;
+  final VoidCallback onInboxTap;
 
   @override
   Widget build(BuildContext context) {
@@ -5807,22 +5824,20 @@ class _DesktopStageShell extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
+              Wrap(
+                spacing: 8,
+                runSpacing: 6,
                 children: [
                   _StageStatusChip(text: signal),
-                  const SizedBox(width: 8),
                   _StageStatusChip(
                     text: classCount == 0
                         ? 'No active classes'
                         : '$classCount classes',
                   ),
-                  if (needsAttention) ...[
-                    const SizedBox(width: 8),
-                    const _StageStatusChip(text: 'Attention'),
-                  ],
+                  if (needsAttention) const _StageStatusChip(text: 'Attention'),
                 ],
               ),
-              const SizedBox(height: 9),
+              const SizedBox(height: 6),
               Text(
                 commandTitle,
                 maxLines: 1,
@@ -5835,7 +5850,7 @@ class _DesktopStageShell extends StatelessWidget {
                   color: OSColors.text(dark),
                 ),
               ),
-              const SizedBox(height: 6),
+              const SizedBox(height: 4),
               Text(
                 commandDetail,
                 maxLines: 1,
@@ -5850,6 +5865,12 @@ class _DesktopStageShell extends StatelessWidget {
           ),
         ),
         const SizedBox(width: 16),
+        _FolderActionButton(
+          label: 'Import data',
+          icon: Icons.cloud_upload_rounded,
+          onTap: onInboxTap,
+        ),
+        const SizedBox(width: 8),
         _FolderActionButton(
           label: primaryActionLabel,
           icon: primaryActionIcon,

--- a/lib/screens/school_data_inbox_screen.dart
+++ b/lib/screens/school_data_inbox_screen.dart
@@ -525,8 +525,9 @@ class _SchoolDataInboxScreenState extends State<SchoolDataInboxScreen> {
                         ),
                         const SizedBox(height: WorkspaceSpacing.lg),
                         _InboxSectionHeader(
-                          title: 'Sources',
-                          subtitle: 'Choose where the file is coming from.',
+                          title: 'Start with a file',
+                          subtitle:
+                              'Choose a source first. InstructOS will detect whether it looks like a calendar, class schedule, roster, score sheet, or teaching resource.',
                         ),
                         const SizedBox(height: WorkspaceSpacing.sm),
                         LayoutBuilder(
@@ -538,7 +539,7 @@ class _SchoolDataInboxScreenState extends State<SchoolDataInboxScreen> {
                                 _InboxActionCard(
                                   title: 'Upload from computer',
                                   subtitle:
-                                      'Pick a CSV, Excel, Word, or ICS file.',
+                                      'Pick a CSV, Excel, Word, or ICS file from this device.',
                                   icon: Icons.upload_file_rounded,
                                   selected: _source == _InboxSource.computer,
                                   enabled: !_busy,
@@ -546,29 +547,38 @@ class _SchoolDataInboxScreenState extends State<SchoolDataInboxScreen> {
                                       () => _source = _InboxSource.computer),
                                 ),
                                 _InboxActionCard(
-                                  title: 'Import from Google Drive',
+                                  title: 'Choose from Google Drive',
                                   subtitle:
-                                      'Opens a Drive file list. Choose a file, then preview extracted data before saving.',
+                                      'Opens a Drive file picker list. Choose a file first; extracted data is previewed before saving.',
                                   icon: Icons.drive_folder_upload_rounded,
                                   selected: _source == _InboxSource.drive,
                                   enabled: !_busy,
                                   onTap: () => setState(
                                       () => _source = _InboxSource.drive),
                                 ),
+                                const _InboxActionCard(
+                                  title: 'Connect school shared folder',
+                                  subtitle:
+                                      'Later, pin a shared Drive folder for calendars, timetables, quizzes, worksheets, rosters, and teaching documents.',
+                                  icon: Icons.snippet_folder_rounded,
+                                  enabled: false,
+                                ),
                               ],
                             );
                           },
                         ),
+                        const SizedBox(height: WorkspaceSpacing.lg),
+                        const _InboxPreviewPanel(),
                         const SizedBox(height: WorkspaceSpacing.xl),
                         _InboxSectionHeader(
-                          title: 'Import types',
+                          title: 'Current supported imports',
                           subtitle:
-                              'This first slice imports class schedules and school calendars. Other data types are staged here for review.',
+                              'These imports already stop for preview and confirmation before saving.',
                         ),
                         const SizedBox(height: WorkspaceSpacing.sm),
                         LayoutBuilder(
                           builder: (context, constraints) {
-                            final narrow = constraints.maxWidth < 840;
+                            final narrow = constraints.maxWidth < 720;
                             return _InboxResponsiveGrid(
                               narrow: narrow,
                               children: [
@@ -592,32 +602,56 @@ class _SchoolDataInboxScreenState extends State<SchoolDataInboxScreen> {
                                     _InboxDestination.schoolCalendar,
                                   ),
                                 ),
-                                const _InboxActionCard(
+                              ],
+                            );
+                          },
+                        ),
+                        const SizedBox(height: WorkspaceSpacing.xl),
+                        _InboxSectionHeader(
+                          title: 'Coming next',
+                          subtitle:
+                              'Future school knowledge tools stay secondary until they are safe to review, undo, and control.',
+                        ),
+                        const SizedBox(height: WorkspaceSpacing.sm),
+                        LayoutBuilder(
+                          builder: (context, constraints) {
+                            final narrow = constraints.maxWidth < 840;
+                            return _InboxResponsiveGrid(
+                              narrow: narrow,
+                              children: const [
+                                _InboxActionCard(
                                   title: 'Teacher timetable',
                                   subtitle:
                                       'Timetable review will land in a later slice.',
                                   icon: Icons.table_chart_rounded,
                                   enabled: false,
                                 ),
-                                const _InboxActionCard(
+                                _InboxActionCard(
                                   title: 'Roster',
                                   subtitle:
                                       'Roster review is visible here, import comes next.',
                                   icon: Icons.groups_rounded,
                                   enabled: false,
                                 ),
-                                const _InboxActionCard(
+                                _InboxActionCard(
                                   title: 'Scores',
                                   subtitle:
                                       'Score imports stay disabled until mapping is added.',
                                   icon: Icons.stacked_bar_chart_rounded,
                                   enabled: false,
                                 ),
-                                const _InboxActionCard(
+                                _InboxActionCard(
                                   title: 'Recent imports',
                                   subtitle:
                                       'Import history and undo controls are coming soon.',
                                   icon: Icons.history_rounded,
+                                  enabled: false,
+                                ),
+                                _InboxActionCard(
+                                  title: 'Ask InstructOS over approved folders',
+                                  subtitle:
+                                      'Later, ask questions over school shared folders after teacher approval.',
+                                  icon: Icons.manage_search_rounded,
                                   enabled: false,
                                 ),
                               ],
@@ -841,7 +875,7 @@ class _InboxHeader extends StatelessWidget {
     final dark = context.isDark;
     return WorkspaceSurfaceCard(
       radius: 8,
-      padding: const EdgeInsets.all(18),
+      padding: const EdgeInsets.all(20),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -864,7 +898,7 @@ class _InboxHeader extends StatelessWidget {
                     ),
                     const SizedBox(height: WorkspaceSpacing.xxs),
                     Text(
-                      'Upload, connect, review, and route school data from one place.',
+                      'The front door for uploads, Drive imports, and future school knowledge.',
                       style: WorkspaceTypography.pageSubtitle(context),
                     ),
                   ],
@@ -873,31 +907,129 @@ class _InboxHeader extends StatelessWidget {
               if (busy) const CircularProgressIndicator.adaptive(),
             ],
           ),
+          const SizedBox(height: WorkspaceSpacing.lg),
+          Text(
+            'Choose a file first. InstructOS will detect what it probably is, then show a preview. Nothing is saved, printed, shared, or sent until you review and confirm.',
+            style: TextStyle(color: OSColors.textSecondary(dark)),
+          ),
           const SizedBox(height: WorkspaceSpacing.md),
           Wrap(
             spacing: WorkspaceSpacing.sm,
             runSpacing: WorkspaceSpacing.sm,
             children: [
-              ChoiceChip(
-                label: const Text('Computer'),
+              _InboxModePill(
+                label: 'Computer',
                 selected: source == _InboxSource.computer,
-                onSelected: onSourceChanged == null
+                onTap: onSourceChanged == null
                     ? null
-                    : (_) => onSourceChanged!(_InboxSource.computer),
+                    : () => onSourceChanged!(_InboxSource.computer),
               ),
-              ChoiceChip(
-                label: const Text('Google Drive'),
+              _InboxModePill(
+                label: 'Google Drive',
                 selected: source == _InboxSource.drive,
-                onSelected: onSourceChanged == null
+                onTap: onSourceChanged == null
                     ? null
-                    : (_) => onSourceChanged!(_InboxSource.drive),
+                    : () => onSourceChanged!(_InboxSource.drive),
+              ),
+              const _InboxModePill(
+                label: 'Shared folder coming soon',
+                selected: false,
               ),
             ],
           ),
-          const SizedBox(height: WorkspaceSpacing.sm),
-          Text(
-            'Google Drive opens a picker list first; extracted import data is previewed before anything is saved.',
-            style: TextStyle(color: OSColors.textSecondary(dark)),
+        ],
+      ),
+    );
+  }
+}
+
+class _InboxModePill extends StatelessWidget {
+  const _InboxModePill({
+    required this.label,
+    required this.selected,
+    this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    final accent = Theme.of(context).colorScheme.primary;
+    return ActionChip(
+      onPressed: onTap,
+      avatar: Icon(
+        selected ? Icons.check_circle_rounded : Icons.circle_outlined,
+        size: 16,
+        color: selected ? accent : OSColors.textMuted(dark),
+      ),
+      label: Text(label),
+      backgroundColor: selected
+          ? accent.withValues(alpha: 0.12)
+          : OSColors.surface(dark).withValues(alpha: 0.82),
+      side: BorderSide(
+        color: selected
+            ? accent.withValues(alpha: 0.32)
+            : OSColors.border(dark).withValues(alpha: 0.6),
+      ),
+    );
+  }
+}
+
+class _InboxPreviewPanel extends StatelessWidget {
+  const _InboxPreviewPanel();
+
+  @override
+  Widget build(BuildContext context) {
+    final dark = context.isDark;
+    return WorkspaceSurfaceCard(
+      radius: 8,
+      padding: const EdgeInsets.all(18),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: OSColors.green.withValues(alpha: 0.14),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: OSColors.green.withValues(alpha: 0.22),
+              ),
+            ),
+            child: const Icon(
+              Icons.fact_check_rounded,
+              color: OSColors.green,
+            ),
+          ),
+          const SizedBox(width: WorkspaceSpacing.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Preview before saving',
+                  style: context.textStyles.titleMedium?.semiBold,
+                ),
+                const SizedBox(height: WorkspaceSpacing.xs),
+                Text(
+                  'Your preview will appear here after you choose a file.',
+                  style: context.textStyles.bodyMedium?.withColor(
+                    OSColors.textSecondary(dark),
+                  ),
+                ),
+                const SizedBox(height: WorkspaceSpacing.xs),
+                Text(
+                  'Nothing is saved until you review and confirm.',
+                  style: context.textStyles.bodySmall?.withColor(
+                    OSColors.textMuted(dark),
+                  ),
+                ),
+              ],
+            ),
           ),
         ],
       ),

--- a/test/os_shell_surfaces_test.dart
+++ b/test/os_shell_surfaces_test.dart
@@ -39,6 +39,7 @@ void main() {
     expect(find.text('Tasks'), findsWidgets);
     expect(find.text('Messages'), findsWidgets);
     expect(find.text('Data Inbox'), findsWidgets);
+    expect(find.text('Import data'), findsOneWidget);
     expect(find.text('Insights'), findsWidgets);
     expect(find.text('Create a class to begin staging teaching tools.'),
         findsNothing);

--- a/test/school_data_inbox_screen_test.dart
+++ b/test/school_data_inbox_screen_test.dart
@@ -124,23 +124,45 @@ void main() {
 
     expect(find.text('School Data Inbox'), findsOneWidget);
     expect(find.text('Upload from computer'), findsOneWidget);
-    expect(find.text('Import from Google Drive'), findsOneWidget);
+    expect(find.text('Choose from Google Drive'), findsOneWidget);
     expect(
       find.text(
-        'Opens a Drive file list. Choose a file, then preview extracted data before saving.',
+        'Opens a Drive file picker list. Choose a file first; extracted data is previewed before saving.',
       ),
       findsOneWidget,
     );
     expect(
       find.text(
-        'Google Drive opens a picker list first; extracted import data is previewed before anything is saved.',
+        'Choose a file first. InstructOS will detect what it probably is, then show a preview. Nothing is saved, printed, shared, or sent until you review and confirm.',
       ),
       findsOneWidget,
     );
+    expect(find.text('Connect school shared folder'), findsOneWidget);
+    expect(
+      find.text(
+        'Later, pin a shared Drive folder for calendars, timetables, quizzes, worksheets, rosters, and teaching documents.',
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Preview before saving'), findsOneWidget);
+    expect(
+      find.text('Your preview will appear here after you choose a file.'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Nothing is saved until you review and confirm.'),
+      findsOneWidget,
+    );
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -700));
+    await tester.pumpAndSettle();
+
     expect(find.text('Class schedule'), findsOneWidget);
+    expect(find.text('School calendar'), findsOneWidget);
     expect(find.text('Teacher timetable'), findsOneWidget);
     expect(find.text('Roster'), findsOneWidget);
     expect(find.text('Scores'), findsOneWidget);
     expect(find.text('Recent imports'), findsOneWidget);
+    expect(find.text('Ask InstructOS over approved folders'), findsOneWidget);
   });
 }


### PR DESCRIPTION
﻿### Files changed
- `lib/os/surfaces/home_surface.dart`
- `lib/screens/school_data_inbox_screen.dart`
- `test/os_shell_surfaces_test.dart`
- `test/school_data_inbox_screen_test.dart`

### UX changed
- Data Inbox is now easier to find from OS Home because the desktop stage has a visible `Import data` call-to-action and the compact/stacked stage has an `Import school data` spotlight tile. Both route to `/os/inbox` without requiring horizontal scrolling.
- The existing launcher tile and pinned app shelf tile are preserved.
- `/os/inbox` is now organized as a premium school data entry point: source choices first, a clear auto-detection explanation, a preview-before-saving empty state, current supported imports, and secondary coming-next capabilities.
- The Google Drive source now explains that it opens a picker/list first, the teacher chooses a file, and extracted data is previewed before saving.
- The shared school folder future direction is represented with a disabled `Connect school shared folder` card explaining that a later slice can pin a shared Drive folder for calendars, timetables, quizzes, worksheets, rosters, and teaching documents.

### Preserved behavior
- No import logic changes.
- No full Google Drive document preview or rendering.
- No Google Drive auto-sync, Drive folder pinning, or background polling.
- No AI extraction implementation.
- No Ask InstructOS behavior, AI/OpenAI code, Firebase Functions, secrets, auth logic, dependency, or storage migration changes.

### Verification results
- `flutter analyze`: `No issues found! (ran in 11.8s)`
- `flutter test test/school_data_inbox_screen_test.dart`: `All tests passed!`
- `flutter test test/os_shell_surfaces_test.dart`: `All tests passed!`
- `flutter test`: `All tests passed!`
- `flutter build web --release --no-wasm-dry-run`: `√ Built build\web`

### Remaining limitations
Full Drive document preview, Drive folder pinning, auto-sync, import history, undo, roster/scores/timetable imports, and AI extraction remain future work.
