### PR TITLE
Quality readiness polish pass

### DIFF
--- a/lib/nav.dart
+++ b/lib/nav.dart
@@ -53,8 +53,10 @@ class AppRouter {
         final loggingIn = state.matchedLocation == AppRoutes.home;
         final previewing =
             kDebugMode && state.matchedLocation == AppRoutes.previewDashboard;
-        debugPrint(
-            'GoRouter.redirect from \'${state.matchedLocation}\' | isAuth=${auth.isAuthenticated} isInit=${auth.isInitialized} isLoading=${auth.isLoading}');
+        if (kDebugMode) {
+          debugPrint(
+              'GoRouter.redirect from \'${state.matchedLocation}\' | isAuth=${auth.isAuthenticated} isInit=${auth.isInitialized} isLoading=${auth.isLoading}');
+        }
         if (!auth.isAuthenticated && !loggingIn && !previewing)
           return AppRouter.loginRedirectLocationFor(state);
         if (auth.isAuthenticated && loggingIn) {

--- a/lib/os/os_app_model.dart
+++ b/lib/os/os_app_model.dart
@@ -182,10 +182,10 @@ class OSAppRegistry {
     ),
     OSApp(
       id: OSAppId.schoolDataInbox,
-      name: 'Data Inbox',
+      name: 'Knowledge Hub',
       icon: Icons.move_to_inbox_rounded,
       category: OSAppCategory.productivity,
-      description: 'Uploads and Drive imports',
+      description: 'Upload, Drive, and shared school data',
       route: '/os/inbox',
       color: Color(0xFF5EC7E6),
     ),

--- a/lib/os/os_assistant.dart
+++ b/lib/os/os_assistant.dart
@@ -1,4 +1,4 @@
-﻿/// GradeFlow OS — AI Assistant Entry
+/// GradeFlow OS — AI Assistant Entry
 ///
 /// [OSAssistantFab] is the always-visible floating AI orb button.
 /// [OSAssistantPanel] is the slide-up panel with suggested actions
@@ -106,14 +106,14 @@ class _OSAssistantPanelState extends State<OSAssistantPanel> {
       _lastResponse = null;
     });
 
-    // Phase 1 placeholder — wire real AI call in Phase 6
+    // This shell panel is a local preview until routed assistant actions land.
     await Future<void>.delayed(const Duration(milliseconds: 800));
 
     if (mounted) {
       setState(() {
         _thinking = false;
         _lastResponse =
-            'AI action routing will be connected in Phase 6. Prompt received: "$prompt"';
+            'This quick assistant panel is still being connected. For teaching-context help today, open Ask InstructOS on Home. I captured: "$prompt"';
       });
     }
   }
@@ -372,7 +372,7 @@ class _AssistantInputBar extends StatelessWidget {
                   color: OSColors.text(dark),
                 ),
                 decoration: InputDecoration(
-                  hintText: 'Ask anything…',
+                  hintText: 'Ask anything...',
                   hintStyle: TextStyle(
                     fontSize: 13,
                     color: OSColors.textMuted(dark),

--- a/lib/os/surfaces/home_surface.dart
+++ b/lib/os/surfaces/home_surface.dart
@@ -2077,7 +2077,7 @@ class _AskInstructOSMiniAppContentState
       _messages
         ..add(_AskInstructOSMessage(text: text, fromAssistant: false))
         ..add(const _AskInstructOSMessage(
-          text: 'Thinking...',
+          text: 'Thinking through your teaching context...',
           fromAssistant: true,
           isPending: true,
         ));
@@ -2599,7 +2599,7 @@ class _AskInstructOSInputRow extends StatelessWidget {
               onSubmitted: (_) => onSend(),
               decoration: InputDecoration(
                 isDense: true,
-                hintText: 'Command InstructOS...',
+                hintText: 'Ask InstructOS...',
                 hintStyle: TextStyle(
                   color: OSColors.textMuted(dark),
                   fontSize: 13,
@@ -2682,20 +2682,20 @@ class _WeatherMiniAppContentState extends State<_WeatherMiniAppContent> {
         final forecast =
             data?.forecast.take(5).toList() ?? const <DashboardForecastDay>[];
         final temp =
-            hasError || loading ? '--' : '${data!.temperatureC.round()}Â°';
+            hasError || loading ? '--' : '${data!.temperatureC.round()} C';
         final condition = hasError
             ? 'Forecast unavailable'
             : loading
                 ? 'Checking forecast'
                 : _weatherLabel(data!.weatherCode);
         final location = hasError
-            ? 'Weather will return when the network responds.'
+            ? 'Forecast is unavailable. Check your connection.'
             : loading
                 ? 'Taichung City'
                 : data!.locationName;
         final feelsLike = data == null
             ? 'Feels-like unavailable'
-            : 'Feels like ${data.apparentTempC.round()}Â°';
+            : 'Feels like ${data.apparentTempC.round()} C';
 
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -2819,11 +2819,11 @@ class _WeatherTeacherNote extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final note = switch (mood) {
-      _WeatherMood.rain => 'Rain signal - indoor transitions may be easier.',
+      _WeatherMood.rain => 'Rainy day: indoor transitions may be easier.',
       _WeatherMood.cloudy =>
         'Cloud cover - keep transitions calm and flexible.',
-      _WeatherMood.sunny => 'Warm afternoon - keep water nearby.',
-      _WeatherMood.night => 'Evening conditions - keep dismissal paths clear.',
+      _WeatherMood.sunny => 'Warm day: keep water nearby.',
+      _WeatherMood.night => 'Evening conditions: keep dismissal paths clear.',
     };
     return _StatusPill(
         label: note, accent: _weatherAccentColor(mood, context.isDark));
@@ -3067,8 +3067,8 @@ class _FocusAudioMiniAppContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final dark = context.isDark;
     final stations = [
-      ('Classroom sound', 'Quiet work and transitions', OSColors.cyan),
-      ('Deep focus', 'Low-distraction study bed', OSColors.indigo),
+      ('Audio preview', 'Playback controls coming soon', OSColors.cyan),
+      ('Deep focus', 'Low-distraction study cue', OSColors.indigo),
       ('Bell reset', 'Short transition cue', OSColors.amber),
     ];
     return Column(
@@ -3099,10 +3099,10 @@ class _FocusAudioMiniAppContent extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const _PanelEyebrow(label: 'Now Playing'),
+                    const _PanelEyebrow(label: 'Preview only'),
                     const SizedBox(height: 5),
                     Text(
-                      'Classroom sound',
+                      'Focus audio',
                       style: TextStyle(
                         fontSize: 18,
                         fontWeight: FontWeight.w900,
@@ -3111,7 +3111,7 @@ class _FocusAudioMiniAppContent extends StatelessWidget {
                     ),
                     const SizedBox(height: 4),
                     Text(
-                      'Stations for quiet work and transitions.',
+                      'Audio playback is coming soon. Use these cues for classroom routines.',
                       style: TextStyle(color: OSColors.textSecondary(dark)),
                     ),
                     const SizedBox(height: 12),
@@ -3153,11 +3153,11 @@ class _FocusAudioMiniAppContent extends StatelessWidget {
               child: const Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  _PanelEyebrow(label: 'Signal'),
+                  _PanelEyebrow(label: 'Cue preview'),
                   SizedBox(height: 12),
                   _MiniEqualizer(),
                   SizedBox(height: 14),
-                  _MiniInputBar(label: 'Add station'),
+                  _MiniInputBar(label: 'Station requests coming soon'),
                 ],
               ),
             );
@@ -3487,7 +3487,7 @@ class _RoundPlayButton extends StatelessWidget {
           ),
         ],
       ),
-      child: const Icon(Icons.play_arrow_rounded, color: Colors.white),
+      child: const Icon(Icons.headphones_rounded, color: Colors.white),
     );
   }
 }
@@ -4544,7 +4544,7 @@ extension _HomeWallpaperStyleX on _HomeWallpaperStyle {
   String get label {
     switch (this) {
       case _HomeWallpaperStyle.defaultStyle:
-        return 'GradeFlow';
+        return 'InstructOS';
       case _HomeWallpaperStyle.sky:
         return 'Sky';
       case _HomeWallpaperStyle.meadow:
@@ -5239,7 +5239,7 @@ class _HomeSystemStrip extends StatelessWidget {
                       Text(
                         teacherName.isEmpty
                             ? schoolName
-                            : '$teacherName Ãƒâ€šÃ‚Â· $schoolName',
+                            : '$teacherName / $schoolName',
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
                         style: TextStyle(
@@ -5685,7 +5685,7 @@ class _HomeStagePanel extends StatelessWidget {
                         title: 'Import school data',
                         icon: Icons.cloud_upload_rounded,
                         accent: OSColors.cyan,
-                        headline: 'Data Inbox',
+                        headline: 'Knowledge Hub',
                         detail:
                             'Upload calendars, schedules, and school files.',
                         onTap: onInboxTap,
@@ -6292,17 +6292,17 @@ class _HomeWeatherPanelState extends State<_HomeWeatherPanel> {
             ? '--'
             : loading
                 ? '--'
-                : '${data!.temperatureC.round()}°';
+                : '${data!.temperatureC.round()} C';
         final conditionLabel = hasError
             ? 'Forecast unavailable'
             : loading
                 ? 'Checking forecast'
                 : _weatherLabel(data!.weatherCode);
         final locationLabel = hasError
-            ? 'Weather will return when the network responds.'
+            ? 'Forecast is unavailable. Check your connection.'
             : loading
                 ? 'Taichung City'
-                : '${data!.locationName} / feels like ${data.apparentTempC.round()}°';
+                : '${data!.locationName} / feels like ${data.apparentTempC.round()} C';
 
         final gap = widget.embedded ? 10.0 : 18.0;
         final tempSize = widget.embedded ? 38.0 : 46.0;
@@ -6704,10 +6704,10 @@ class _HomeAudioPanel extends StatelessWidget {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const _PanelEyebrow(label: 'Focus Audio'),
+                    const _PanelEyebrow(label: 'Focus Audio Preview'),
                     const SizedBox(height: 5),
                     Text(
-                      'Classroom sound',
+                      'Sound cues',
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(
@@ -6718,7 +6718,7 @@ class _HomeAudioPanel extends StatelessWidget {
                     ),
                     const SizedBox(height: 3),
                     Text(
-                      'Stations for quiet work and transitions.',
+                      'Preview only: playback is coming soon.',
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: TextStyle(

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -377,7 +377,7 @@ class _LoginScreenState extends State<LoginScreen> {
             onPressed: _isLoading ? null : _handleDemoLogin,
             style: secondaryButtonStyle,
             icon: const Icon(Icons.preview_outlined),
-            label: const Text('Open demo'),
+            label: const Text('Open demo workspace'),
           ),
           const SizedBox(height: 18),
           TextButton(
@@ -443,8 +443,10 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     final auth = context.watch<AuthService>();
     final router = GoRouter.of(context);
-    debugPrint(
-        'LoginScreen.build | isAuth=${auth.isAuthenticated} isLoading=${auth.isLoading} isInit=${auth.isInitialized}');
+    if (kDebugMode) {
+      debugPrint(
+          'LoginScreen.build | isAuth=${auth.isAuthenticated} isLoading=${auth.isLoading} isInit=${auth.isInitialized}');
+    }
     if (auth.isAuthenticated) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (!mounted) return;

--- a/lib/screens/school_data_inbox_screen.dart
+++ b/lib/screens/school_data_inbox_screen.dart
@@ -549,7 +549,7 @@ class _SchoolDataInboxScreenState extends State<SchoolDataInboxScreen> {
         child: userId == null
             ? const WorkspaceLoadingState(
                 title: 'Restoring workspace',
-                subtitle: 'Preparing the School Data Inbox.',
+                subtitle: 'Preparing the School Knowledge Hub.',
               )
             : CustomScrollView(
                 slivers: [

--- a/test/login_screen_test.dart
+++ b/test/login_screen_test.dart
@@ -42,6 +42,6 @@ void main() {
     expect(tester.takeException(), isNull);
     expect(find.text('InstructOS'), findsOneWidget);
     expect(find.text('Sign in'), findsOneWidget);
-    expect(find.text('Open demo'), findsOneWidget);
+    expect(find.text('Open demo workspace'), findsOneWidget);
   });
 }

--- a/test/os_shell_surfaces_test.dart
+++ b/test/os_shell_surfaces_test.dart
@@ -38,7 +38,7 @@ void main() {
     expect(find.text('Classes'), findsWidgets);
     expect(find.text('Tasks'), findsWidgets);
     expect(find.text('Messages'), findsWidgets);
-    expect(find.text('Data Inbox'), findsWidgets);
+    expect(find.text('Knowledge Hub'), findsWidgets);
     expect(find.text('Import data'), findsOneWidget);
     expect(find.text('Insights'), findsWidgets);
     expect(find.text('Create a class to begin staging teaching tools.'),


### PR DESCRIPTION
## Summary
- Tightens visible InstructOS/Knowledge Hub naming and removes stale Data Inbox copy in the shell/loading state.
- Makes rough placeholder surfaces more honest: audio is labeled as a preview, weather copy avoids corrupted degree symbols, and the shell assistant no longer mentions internal phase routing.
- Gates noisy route/login debug logging behind debug mode and clarifies the demo login CTA.

## Verification
- flutter analyze
- flutter test test/os_shell_surfaces_test.dart test/login_screen_test.dart test/school_data_inbox_screen_test.dart
- flutter test
- flutter build web --release --no-wasm-dry-run
- Manual Chrome smoke pass on release build for login, /os/home, /os/inbox, classes, class workspace, seating, gradebook, planner

## Notes
This is intentionally a small first-batch quality pass. Larger product-readiness issues are left for scoped follow-up PRs.